### PR TITLE
Add an implicit diffusion solver as a utility method

### DIFF
--- a/simulation/diffusion.py
+++ b/simulation/diffusion.py
@@ -1,0 +1,46 @@
+import numpy as np
+from scipy.sparse.linalg import gmres, LinearOperator
+
+from simulation.state import RectangularGrid
+
+
+# TODO: Boundary conditions?
+def discrete_laplacian(grid: RectangularGrid, dtype: np.dtype, dt: float) -> LinearOperator:
+    """Return a discrete laplacian operator for the given grid."""
+    dz = grid.delta(0)
+    dy = grid.delta(1)
+    dx = grid.delta(2)
+
+    hz2 = dt / np.square(dz[1:-1, :, :])
+    hy2 = dt / np.square(dy[:, 1:-1, :])
+    hx2 = dt / np.square(dx[:, :, 1:-1])
+
+    def matvec(var: np.ndarray) -> np.ndarray:
+        var = var.reshape(grid.shape)
+
+        # Discrete laplacian
+        lapl = np.zeros(grid.shape, dtype=var.dtype)
+        lapl[1:-1, :, :] -= (var[2:, :, :] - 2 * var[1:-1, :, :] + var[:-2, :, :]) * hz2
+        lapl[:, 1:-1, :] -= (var[:, 2:, :] - 2 * var[:, 1:-1, :] + var[:, :-2, :]) * hy2
+        lapl[:, :, 1:-1] -= (var[:, :, 2:] - 2 * var[:, :, 1:-1] + var[:, :, :-2]) * hx2
+
+        # RHS (TODO: implement 2nd order time stepping?)
+        lapl += var
+        return lapl
+
+    n = len(grid)
+    return LinearOperator(matvec=matvec, dtype=dtype, shape=(n, n))
+
+
+def diffusion_step(grid: RectangularGrid, var: np.ndarray,
+                   diffusivity: float, dt: float) -> None:
+    """Apply diffusion to a variable.
+
+    Solves laplaces equation in 3D using implicit time steps.  The variable is
+    advanced in time by `dt` time units using gmres.
+    """
+    lapl = discrete_laplacian(grid, var.dtype, dt)
+    var_next, info = gmres(lapl, var.ravel())
+    if info != 0:
+        raise Exception(f'GMRES failed ({info})')
+    var[:] = var_next.reshape(grid.shape)

--- a/simulation/state.py
+++ b/simulation/state.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from io import BytesIO
 from pathlib import PurePath
 from tempfile import NamedTemporaryFile
@@ -79,6 +80,9 @@ class RectangularGrid(object):
     @property
     def shape(self) -> ShapeType:
         return (len(self.z), len(self.y), len(self.x))
+
+    def __len__(self):
+        return reduce(lambda x, y: x * y, self.shape, 1)
 
     def allocate_variable(self, dtype: np.dtype = np.dtype('float64')) -> np.ndarray:
         """Allocate a numpy array defined over this grid."""


### PR DESCRIPTION
This adds a diffusion operator (with implicit time stepping) similar to the one [defined in the old framework](https://github.com/NutritionalLungImmunity/invasive-aspergillosis/blob/master/Diffusion/src/main/java/edu/uchc/Diffusion/Diffusion.java) except it uses GMRES rather than conjugate gradient as a solver.