### PR TITLE
Implement a cell tree using numpy record arrays

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "da6db5c731bd5808d3f5b411144f28adef9f7b04ee52b845439f530fab23e468"
+            "sha256": "a518e235c3a52174b0e26491747bd4c38422e115624e5de627900fdd31205297"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -72,7 +72,9 @@
         "kiwisolver": {
             "hashes": [
                 "sha256:05b5b061e09f60f56244adc885c4a7867da25ca387376b02c1efc29cc16bcd0f",
+                "sha256:210d8c39d01758d76c2b9a693567e1657ec661229bc32eac30761fa79b2474b0",
                 "sha256:26f4fbd6f5e1dabff70a9ba0d2c4bd30761086454aa30dddc5b52764ee4852b7",
+                "sha256:3b15d56a9cd40c52d7ab763ff0bc700edbb4e1a298dc43715ecccd605002cf11",
                 "sha256:3b2378ad387f49cbb328205bda569b9f87288d6bc1bf4cd683c34523a2341efe",
                 "sha256:400599c0fe58d21522cae0e8b22318e09d9729451b17ee61ba8e1e7c0346565c",
                 "sha256:47b8cb81a7d18dbaf4fed6a61c3cecdb5adec7b4ac292bddb0d016d57e8507d5",
@@ -81,16 +83,22 @@
                 "sha256:5a52e1b006bfa5be04fe4debbcdd2688432a9af4b207a3f429c74ad625022641",
                 "sha256:5c7ca4e449ac9f99b3b9d4693debb1d6d237d1542dd6a56b3305fe8a9620f883",
                 "sha256:682e54f0ce8f45981878756d7203fd01e188cc6c8b2c5e2cf03675390b4534d5",
+                "sha256:76275ee077772c8dde04fb6c5bc24b91af1bb3e7f4816fd1852f1495a64dad93",
                 "sha256:79bfb2f0bd7cbf9ea256612c9523367e5ec51d7cd616ae20ca2c90f575d839a2",
                 "sha256:7f4dd50874177d2bb060d74769210f3bce1af87a8c7cf5b37d032ebf94f0aca3",
                 "sha256:8944a16020c07b682df861207b7e0efcd2f46c7488619cb55f65882279119389",
                 "sha256:8aa7009437640beb2768bfd06da049bad0df85f47ff18426261acecd1cf00897",
+                "sha256:9105ce82dcc32c73eb53a04c869b6a4bc756b43e4385f76ea7943e827f529e4d",
+                "sha256:933df612c453928f1c6faa9236161a1d999a26cd40abf1dc5d7ebbc6dbfb8fca",
                 "sha256:939f36f21a8c571686eb491acfffa9c7f1ac345087281b412d63ea39ca14ec4a",
+                "sha256:9491578147849b93e70d7c1d23cb1229458f71fc79c51d52dce0809b2ca44eea",
                 "sha256:9733b7f64bd9f807832d673355f79703f81f0b3e52bfce420fc00d8cb28c6a6c",
                 "sha256:a02f6c3e229d0b7220bd74600e9351e18bc0c361b05f29adae0d10599ae0e326",
                 "sha256:a0c0a9f06872330d0dd31b45607197caab3c22777600e88031bfe66799e70bb0",
+                "sha256:aa716b9122307c50686356cfb47bfbc66541868078d0c801341df31dca1232a9",
                 "sha256:acc4df99308111585121db217681f1ce0eecb48d3a828a2f9bbf9773f4937e9e",
                 "sha256:b64916959e4ae0ac78af7c3e8cef4becee0c0e9694ad477b4c6b3a536de6a544",
+                "sha256:d22702cadb86b6fcba0e6b907d9f84a312db9cd6934ee728144ce3018e715ee1",
                 "sha256:d3fcf0819dc3fea58be1fd1ca390851bdb719a549850e708ed858503ff25d995",
                 "sha256:d52e3b1868a4e8fd18b5cb15055c76820df514e26aa84cc02f593d99fef6707f",
                 "sha256:db1a5d3cc4ae943d674718d6c47d2d82488ddd94b93b9e12d24aabdbfe48caee",
@@ -98,7 +106,8 @@
                 "sha256:e8bf074363ce2babeb4764d94f8e65efd22e6a7c74860a4f05a6947afc020ff2",
                 "sha256:f16814a4a96dc04bf1da7d53ee8d5b1d6decfc1a92a63349bb15d37b6a263dd9",
                 "sha256:f2b22153870ca5cf2ab9c940d7bc38e8e9089fa0f7e5856ea195e1cf4ff43d5a",
-                "sha256:f790f8b3dff3d53453de6a7b7ddd173d2e020fb160baff578d578065b108a05f"
+                "sha256:f790f8b3dff3d53453de6a7b7ddd173d2e020fb160baff578d578065b108a05f",
+                "sha256:fe51b79da0062f8e9d49ed0182a626a7dc7a0cbca0328f612c6ee5e4711c81e4"
             ],
             "version": "==1.1.0"
         },
@@ -118,43 +127,69 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0b0dd8f47fb177d00fa6ef2d58783c4f41ad3126b139c91dd2f7c4b3fdf5e9a5",
-                "sha256:25ffe71f96878e1da7e014467e19e7db90ae7d4e12affbc73101bcf61785214e",
-                "sha256:26efd7f7d755e6ca966a5c0ac5a930a87dbbaab1c51716ac26a38f42ecc9bc4b",
-                "sha256:28b1180c758abf34a5c3fea76fcee66a87def1656724c42bb14a6f9717a5bdf7",
-                "sha256:2e418f0a59473dac424f888dd57e85f77502a593b207809211c76e5396ae4f5c",
-                "sha256:30c84e3a62cfcb9e3066f25226e131451312a044f1fe2040e69ce792cb7de418",
-                "sha256:4650d94bb9c947151737ee022b934b7d9a845a7c76e476f3e460f09a0c8c6f39",
-                "sha256:4dd830a11e8724c9c9379feed1d1be43113f8bcce55f47ea7186d3946769ce26",
-                "sha256:4f2a2b279efde194877aff1f76cf61c68e840db242a5c7169f1ff0fd59a2b1e2",
-                "sha256:62d22566b3e3428dfc9ec972014c38ed9a4db4f8969c78f5414012ccd80a149e",
-                "sha256:669795516d62f38845c7033679c648903200980d68935baaa17ac5c7ae03ae0c",
-                "sha256:75fcd60d682db3e1f8fbe2b8b0c6761937ad56d01c1dc73edf4ef2748d5b6bc4",
-                "sha256:9395b0a41e8b7e9a284e3be7060db9d14ad80273841c952c83a5afc241d2bd98",
-                "sha256:9e37c35fc4e9410093b04a77d11a34c64bf658565e30df7cbe882056088a91c1",
-                "sha256:a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e",
-                "sha256:b46554ad4dafb2927f88de5a1d207398c5385edbb5c84d30b3ef187c4a3894d8",
-                "sha256:c867eeccd934920a800f65c6068acdd6b87e80d45cd8c8beefff783b23cdc462",
-                "sha256:dd0667f5be56fb1b570154c2c0516a528e02d50da121bbbb2cbb0b6f87f59bc2",
-                "sha256:de2b1c20494bdf47f0160bd88ed05f5e48ae5dc336b8de7cfade71abcc95c0b9",
-                "sha256:f1df7b2b7740dd777571c732f98adb5aad5450aee32772f1b39249c8a50386f6",
-                "sha256:ffca69e29079f7880c5392bf675eb8b4146479d976ae1924d01cd92b04cccbcc"
+                "sha256:0a7a1dd123aecc9f0076934288ceed7fd9a81ba3919f11a855a7887cbe82a02f",
+                "sha256:0c0763787133dfeec19904c22c7e358b231c87ba3206b211652f8cbe1241deb6",
+                "sha256:3d52298d0be333583739f1aec9026f3b09fdfe3ddf7c7028cb16d9d2af1cca7e",
+                "sha256:43bb4b70585f1c2d153e45323a886839f98af8bfa810f7014b20be714c37c447",
+                "sha256:475963c5b9e116c38ad7347e154e5651d05a2286d86455671f5b1eebba5feb76",
+                "sha256:64874913367f18eb3013b16123c9fed113962e75d809fca5b78ebfbb73ed93ba",
+                "sha256:683828e50c339fc9e68720396f2de14253992c495fdddef77a1e17de55f1decc",
+                "sha256:6ca4000c4a6f95a78c33c7dadbb9495c10880be9c89316aa536eac359ab820ae",
+                "sha256:75fd817b7061f6378e4659dd792c84c0b60533e867f83e0d1e52d5d8e53df88c",
+                "sha256:7d81d784bdbed30137aca242ab307f3e65c8d93f4c7b7d8f322110b2e90177f9",
+                "sha256:8d0af8d3664f142414fd5b15cabfd3b6cc3ef242a3c7a7493257025be5a6955f",
+                "sha256:9679831005fb16c6df3dd35d17aa31dc0d4d7573d84f0b44cc481490a65c7725",
+                "sha256:a8f67ebfae9f575d85fa859b54d3bdecaeece74e3274b0b5c5f804d7ca789fe1",
+                "sha256:acbf5c52db4adb366c064d0b7c7899e3e778d89db585feadd23b06b587d64761",
+                "sha256:ada4805ed51f5bcaa3a06d3dd94939351869c095e30a2b54264f5a5004b52170",
+                "sha256:c7354e8f0eca5c110b7e978034cd86ed98a7a5ffcf69ca97535445a595e07b8e",
+                "sha256:e2e9d8c87120ba2c591f60e32736b82b67f72c37ba88a4c23c81b5b8fa49c018",
+                "sha256:e467c57121fe1b78a8f68dd9255fbb3bb3f4f7547c6b9e109f31d14569f490c3",
+                "sha256:ede47b98de79565fcd7f2decb475e2dcc85ee4097743e551fe26cfc7eb3ff143",
+                "sha256:f58913e9227400f1395c7b800503ebfdb0772f1c33ff8cb4d6451c06cabdf316",
+                "sha256:fe39f5fd4103ec4ca3cb8600b19216cd1ff316b4990f4c0b6057ad982c0a34d5"
             ],
-            "version": "==1.17.3"
+            "version": "==1.17.4"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.5"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
-                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "version": "==2.8.0"
+            "version": "==2.8.1"
+        },
+        "scipy": {
+            "hashes": [
+                "sha256:0359576d8cc058bd615999cf985e2423dc6cc824666d60e8b8d4810569a04655",
+                "sha256:07673b5b96dbe28c88f3a53ca9af67f802aa853de7402e31f473b4dd6501c799",
+                "sha256:0f81e71149539ac09053a3f9165659367b060eceef3bbde11e6600e1c341f1f2",
+                "sha256:125aa82f7b3d4bd7f77fed6c3c6e31be47e33f129d829799569389ae59f913e7",
+                "sha256:2dc26e5b3eb86b7adad506b6b04020f6a87e1102c9acd039e937d28bdcee7fa6",
+                "sha256:2e4b5fdb635dd425bf46fbd6381612692d3c795f1eb6fe62410305a440691d46",
+                "sha256:33ac3213ee617bbc0eac84d02b130d69093ed7738afb281dfdeb12a9dbdf1530",
+                "sha256:34c48d922760782732d6f8f4532e320984d1280763c6787c6582021d34c8ad79",
+                "sha256:3f556f63e070e9596624e42e99d23b259d8f0fc63ec093bef97a9f1c579565b2",
+                "sha256:470d8fc76ccab6cfff60a9de4ce316a23ee7f63615d948c7446dc7c1bb45042d",
+                "sha256:4ad7a3ae9831d2085d6f50b81bfcd76368293eafdf31f4ac9f109c6061309c24",
+                "sha256:61812a7db0d9bc3f13653e52b8ddb1935cf444ec55f39160fc2778aeb2719057",
+                "sha256:7a0477929e6f9d5928fe81fe75d00b7da9545a49109e66028d85848b18aeef99",
+                "sha256:9c3221039da50f3b60da70b65d6b020ea26cefbb097116cfec696010432d1f6c",
+                "sha256:a03939b431994289f39373c57bbe452974a7da724ae7f9620a1beee575434da4",
+                "sha256:df4dbd3d40db3f667e0145dba5f50954bf28b2dd5b8b400c79d5e3fe8cb67ce2",
+                "sha256:e837c8068bd1929a533e9d51562faf6584ddb5303d9e218d8c11aa4719dcd617",
+                "sha256:ecfd45ca0ce1d6c13bef17794b4052cc9a9574f4be8d44c9bcfd7e34294bd2d7",
+                "sha256:ee5888c62cd83c9bf9927ffcee08434e7d5c81a8f31e5b85af5470e511022c08",
+                "sha256:f018892621b787b9abf76d51d1f0c21611c71752ebb1891ccf7992e0bf973708",
+                "sha256:f2d5db81d90d14a32d4aff920f52fca5639bcaaaf87b4f61bce83a1d238f49fc"
+            ],
+            "version": "==1.3.2"
         },
         "simulation": {
             "editable": true,
@@ -162,10 +197,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "vtk": {
             "hashes": [
@@ -181,7 +216,6 @@
                 "sha256:e790aed1a776d3682b2c38a5a795a0f46e3043f96ed113a3bbaf7ef5eaaeba08",
                 "sha256:ee17372ded18987480e3e07405f9b36fc4e2a0c1da1503628c4980a3957d7c98"
             ],
-            "index": "pypi",
             "version": "==8.1.2"
         }
     },
@@ -199,14 +233,6 @@
                 "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
             "version": "==19.3.0"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
-                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.1"
         },
         "coverage": {
             "hashes": [
@@ -284,10 +310,10 @@
         },
         "flake8-quotes": {
             "hashes": [
-                "sha256:5dbaf668887873f28346fb87943d6da2e4b9f77ce9f2169cff21764a0a4934ed"
+                "sha256:11a15d30c92ca5f04c2791bd7019cf62b6f9d3053eb050d02a135557eb118bfc"
             ],
             "index": "pypi",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "importlib-metadata": {
             "hashes": [
@@ -347,11 +373,11 @@
         },
         "pep8-naming": {
             "hashes": [
-                "sha256:01cb1dab2f3ce9045133d08449f1b6b93531dceacb9ef04f67087c11c723cea9",
-                "sha256:0ec891e59eea766efd3059c3d81f1da304d858220678bdc351aab73c533f2fbb"
+                "sha256:909fb830d47295dc1fab5bb69db5ffb22ce1d0e90782aa38de7611da8a587ea2",
+                "sha256:c572c652904cb76581bc326f498b23574306ad253a069c75633f7c12eb46b91a"
             ],
             "index": "pypi",
-            "version": "==0.8.2"
+            "version": "==0.9.0"
         },
         "pluggy": {
             "hashes": [
@@ -383,10 +409,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.5"
         },
         "pytest": {
             "hashes": [
@@ -406,10 +432,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "toml": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         'h5py',
         'matplotlib',
         'numpy',
+        'scipy',
         'vtk'
     ],
     entry_points={

--- a/simulation/cell.py
+++ b/simulation/cell.py
@@ -170,7 +170,8 @@ class CellTree(object):
 
         if len(cells) > 0:
             self._cells[:len(cells)] = cells
-            self._adjacency[:adjacency.shape[0], :adjacency.shape[1]] = adjacency
+            for key, value in adjacency.items():
+                self._adjacency[key] = value
 
     def __len__(self) -> int:
         return self._ncells

--- a/simulation/cell.py
+++ b/simulation/cell.py
@@ -10,7 +10,7 @@ BOOLEAN_NETWORK_LENGTH = 23
 GROWTH_SCALE_FACTOR = 0.02  # from original code
 
 
-class CellTree(np.ndarray):
+class CellArray(np.ndarray):
     dtype = np.dtype([
         ('point', Point.dtype),
         ('growth', Point.dtype),
@@ -99,7 +99,7 @@ class CellTree(np.ndarray):
             (grid.zv[0] <= point.z) & (point.z <= grid.zv[-1])
         )
 
-    def elongate(self, grid: RectangularGrid) -> 'CellTree':
+    def elongate(self, grid: RectangularGrid) -> 'CellArray':
         mask = (
             self['growable'] &
             (self['status'] == self.Status.HYPHAE) &
@@ -109,16 +109,16 @@ class CellTree(np.ndarray):
         self['growable'][mask] = False
         self['branchable'][mask] = True
 
-        children = CellTree(mask.sum())
+        children = CellArray(mask.sum())
         self['iron_pool'][mask] /= 2
         children['iron_pool'] = self['iron_pool'][mask]
         children['point'] = self['point'][mask] + self['growth'][mask]
         children['growth'] = self['growth'][mask]
 
-        a = np.append(self, children).view(CellTree)
+        a = np.append(self, children).view(CellArray)
         return a
 
-    def branch(self, branch_probability: float, grid: RectangularGrid) -> 'CellTree':
+    def branch(self, branch_probability: float, grid: RectangularGrid) -> 'CellArray':
         indices = (
             self['branchable'] &
             (self['status'] == self.Status.HYPHAE) &
@@ -128,7 +128,7 @@ class CellTree(np.ndarray):
         if len(indices) == 0:
             return self
 
-        children = CellTree(len(indices))
+        children = CellArray(len(indices))
         children['growth'] = np.apply_along_axis(
             self.random_branch_direction, 1, children['growth'])
 
@@ -146,4 +146,4 @@ class CellTree(np.ndarray):
         children['growable'] = True
         children['branchable'] = False
 
-        return np.append(self, children).view(CellTree)
+        return np.append(self, children).view(CellArray)

--- a/simulation/cell.py
+++ b/simulation/cell.py
@@ -1,0 +1,149 @@
+from enum import IntEnum
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from simulation.coordinates import Point
+from simulation.state import RectangularGrid
+
+BOOLEAN_NETWORK_LENGTH = 23
+GROWTH_SCALE_FACTOR = 0.02  # from original code
+
+
+class CellTree(np.ndarray):
+    dtype = np.dtype([
+        ('point', Point.dtype),
+        ('growth', Point.dtype),
+        ('boolean_network', 'b1', BOOLEAN_NETWORK_LENGTH),
+        ('state', 'u1'),
+        ('status', 'u1'),
+        ('growable', 'b1'),
+        ('switched', 'b1'),
+        ('branchable', 'b1'),
+        ('iron_pool', 'f8'),
+        ('iron', 'b1'),
+        ('iteration', 'i4')
+    ], align=True)
+
+    class Status(IntEnum):
+        RESTING_CONIDIA = 0
+        SWELLING_CONIDIA = 1
+        HYPHAE = 2
+        DYING = 3
+        DEAD = 4
+
+    class State(IntEnum):
+        FREE = 0
+        INTERNALIZING = 1
+        RELEASING = 2
+
+    def __new__(cls, length: int, **kwargs):
+        return np.asarray([
+            cls.create(**kwargs) for _ in range(length)
+        ], dtype=cls.dtype).view(cls)
+
+    @classmethod
+    def create(cls, point: Point = None, iron_pool: float = 0,
+               status: Status = Status.RESTING_CONIDIA,
+               state: State = State.FREE) -> np.record:
+
+        if point is None:
+            point = Point()
+        growth = GROWTH_SCALE_FACTOR * Point.from_array(2 * np.random.rand(3) - 1)
+        network = cls.initial_boolean_network()
+        growable = True
+        switched = False
+        branchable = False
+        iteration = 0
+        iron = False
+
+        return np.rec.array([
+            (point, growth, network, state, status, growable,
+             switched, branchable, iron_pool, iron, iteration)
+        ], dtype=cls.dtype)[0]
+
+    @classmethod
+    def initial_boolean_network(cls) -> np.ndarray:
+        return np.asarray([
+            True, False, True, False, True, True, True, True, True, False, False, False,
+            True, False, False, False, False, False, False, False, False, False, False
+        ])
+
+    @classmethod
+    def random_branch_direction(cls, growth: np.ndarray) -> np.ndarray:
+        """Rotate by a random 45 degree angle from the axis of growth."""
+        growth = Point.from_array(growth)
+
+        # get a random vector orthogonal to the growth vector
+        axis = Point.from_array(np.cross(growth, np.random.randn(3)))
+        axis = (np.pi / 4) * axis / axis.norm()
+
+        # rotate the growth vector 45 degrees along the random axis
+        rotation = Rotation.from_rotvec(axis)
+        return rotation.apply(growth)
+
+    @classmethod
+    def point_mask(cls, points: np.ndarray, grid: RectangularGrid):
+        """Generate a mask array from a set of points.
+
+        The output is a boolean array indicating if the point at that index
+        is a valid location for a cell.
+        """
+        assert points.shape[1] == 3, 'Invalid point array shape'
+        point = points.T.view(Point)
+
+        # TODO: add geometry restriction
+        return (
+            (grid.xv[0] <= point.x) & (point.x <= grid.xv[-1]) &
+            (grid.yv[0] <= point.y) & (point.y <= grid.yv[-1]) &
+            (grid.zv[0] <= point.z) & (point.z <= grid.zv[-1])
+        )
+
+    def elongate(self, grid: RectangularGrid) -> 'CellTree':
+        mask = (
+            self['growable'] &
+            (self['status'] == self.Status.HYPHAE) &
+            self.point_mask(self['point'] + self['growth'], grid)
+        )
+
+        self['growable'][mask] = False
+        self['branchable'][mask] = True
+
+        children = CellTree(mask.sum())
+        self['iron_pool'][mask] /= 2
+        children['iron_pool'] = self['iron_pool'][mask]
+        children['point'] = self['point'][mask] + self['growth'][mask]
+        children['growth'] = self['growth'][mask]
+
+        a = np.append(self, children).view(CellTree)
+        return a
+
+    def branch(self, branch_probability: float, grid: RectangularGrid) -> 'CellTree':
+        indices = (
+            self['branchable'] &
+            (self['status'] == self.Status.HYPHAE) &
+            (np.random.rand(*self.shape) < branch_probability)
+        ).nonzero()[0]
+
+        if len(indices) == 0:
+            return self
+
+        children = CellTree(len(indices))
+        children['growth'] = np.apply_along_axis(
+            self.random_branch_direction, 1, children['growth'])
+
+        children['point'] = self['point'][indices] + children['growth'][indices]
+        children['iron_pool'] = self['iron_pool'][indices] / 2
+
+        # filter out children lying outside of the domain
+        indices = indices[self.point_mask(children['point'], grid)]
+
+        # set iron content for branched cells
+        self['iron_pool'][indices] /= 2
+
+        # set properties
+        self['branchable'][indices] = False
+        children['growable'] = True
+        children['branchable'] = False
+
+        return np.append(self, children).view(CellTree)

--- a/simulation/coordinates.py
+++ b/simulation/coordinates.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+
+class Point(np.ndarray):
+    """An array subclass representing a point or vector in 3D space."""
+    dtype = np.dtype((np.dtype('<f8'), (3,)))
+
+    def __new__(cls, x: float = 0, y: float = 0, z: float = 0) -> 'Point':
+        return np.asarray([z, y, x], dtype=np.float64).view(cls)
+
+    @classmethod
+    def from_array(cls, array: np.ndarray) -> 'Point':
+        if array.shape != (3,):
+            raise ValueError('Invalid shape for point object')
+        return array.view(cls)
+
+    @property
+    def x(self) -> float:
+        return self[2]
+
+    @x.setter
+    def x(self, value: float):
+        self[2] = value
+
+    @property
+    def y(self) -> float:
+        return self[1]
+
+    @y.setter
+    def y(self, value: float):
+        self[1] = value
+
+    @property
+    def z(self) -> float:
+        return self[0]
+
+    @z.setter
+    def z(self, value: float):
+        self[0] = value
+
+    def norm(self, ord: float = 2):
+        return np.linalg.norm(self, ord=ord)

--- a/simulation/module.py
+++ b/simulation/module.py
@@ -1,9 +1,12 @@
-from typing import Any, Dict, Optional, Type, Union
+from importlib import import_module
+from typing import Any, cast, Dict, Optional, Type, Union
 
 import attr
 from h5py import Dataset, Group
 import numpy as np
+from scipy.sparse import coo_matrix
 
+from simulation.cell import CellTree, MAX_CELL_TREE_SIZE
 from simulation.config import SimulationConfig
 from simulation.state import State
 
@@ -39,22 +42,33 @@ class ModuleState(object):
             if name == 'global_state':
                 continue
             metadata = field.metadata
-            kwargs[name] = cls.load_attribute(group, name, metadata)
+            if metadata.get('cell_tree'):
+                kwargs[name] = cls.load_cell_tree(global_state, group, name, metadata)
+            else:
+                kwargs[name] = cls.load_attribute(global_state, group, name, metadata)
         return cls(**kwargs)
 
     @classmethod
     def save_attribute(cls, group: Group,
                        name: str, value: AttrValue,
-                       metadata: Optional[dict] = None) -> Dataset:
+                       metadata: dict = None) -> Union[Dataset, Group]:
         """Save an attribute into an HDF5 group."""
-        metadata = metadata or {}
 
-        if not isinstance(value, (float, int, str, bool, np.ndarray)):
+        metadata = metadata or {}
+        if isinstance(value, (float, int, str, bool, np.ndarray)):
+            return cls.save_simple_type(group, name, value, metadata)
+        elif isinstance(value, CellTree):
+            return cls.save_cell_tree(group, name, value, metadata)
+        else:
             # modules must define serializers for unsupported types
             raise TypeError(
                 f'Attribute {name} in {group.name} contains an unsupported datatype.'
             )
 
+    @classmethod
+    def save_simple_type(cls, group: Group,
+                         name: str, value: AttrValue,
+                         metadata: dict) -> Dataset:
         kwargs: Dict[str, Any] = {}
         if metadata.get('grid'):
             kwargs = dict(
@@ -77,7 +91,27 @@ class ModuleState(object):
         return var
 
     @classmethod
-    def load_attribute(cls, group: Group, name: str, metadata: Optional[dict] = None) -> AttrValue:
+    def save_cell_tree(cls, group: Group,
+                       name: str, value: CellTree,
+                       metadata: dict) -> Group:
+        composite_group = group.create_group(name)
+
+        class_ = value.__class__
+        composite_group.attrs['type'] = 'CellTree'
+        composite_group.attrs['class'] = f'{class_.__module__}:{class_.__name__}'
+        composite_group.attrs['max_size'] = value.max_cells
+
+        composite_group.create_dataset(name='cells', data=value.cells)
+
+        sp = value.adjacency.tocoo()
+        composite_group.create_dataset(name='row', data=sp.row)
+        composite_group.create_dataset(name='col', data=sp.col)
+        composite_group.create_dataset(name='value', data=sp.data)
+        return composite_group
+
+    @classmethod
+    def load_attribute(cls, global_state: State, group: Group, name: str,
+                       metadata: Optional[dict] = None) -> AttrValue:
         """Load a raw value from an HDF5 file group."""
         dataset = group[name]
         if dataset.attrs.get('scalar', False):
@@ -85,6 +119,37 @@ class ModuleState(object):
         else:
             value = dataset[:]
         return value
+
+    @classmethod
+    def load_cell_tree(cls, global_state: State, group: Group, name: str,
+                       metadata: Optional[dict] = None) -> CellTree:
+        composite_dataset = group[name]
+
+        attrs = composite_dataset.attrs
+        if attrs.get('type') != 'CellTree' or attrs.get('class') is None:
+            raise TypeError(f'File contains invalid type for {name}')
+
+        module_name, class_name = attrs['class'].split(':')
+        try:
+            module = import_module(module_name)
+        except ImportError:
+            raise TypeError(f'File references unknown module {module_name} in {name}')
+
+        class_ = getattr(module, class_name, None)
+        if class_ is None:
+            raise TypeError(f'File references invalid class for {name}')
+
+        class_ = cast(Type[CellTree], class_)
+        max_size = attrs.get('max_size', MAX_CELL_TREE_SIZE)
+
+        adjacency = coo_matrix((
+            composite_dataset['value'],
+            (composite_dataset['row'], composite_dataset['col'])),
+            shape=(max_size, max_size)
+        ).todok()
+        cells = composite_dataset['cells'][:].view(class_.CellArrayClass)
+
+        return class_(grid=global_state.grid, cells=cells, adjacency=adjacency)
 
 
 class Module(object):

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -1,9 +1,12 @@
 from enum import IntEnum
 
+import attr
 import numpy as np
 
 from simulation.cell import CellArray, CellTree
 from simulation.coordinates import Point
+from simulation.module import Module, ModuleState
+from simulation.state import cell_tree
 
 BOOLEAN_NETWORK_LENGTH = 23
 
@@ -83,3 +86,13 @@ class AfumigatusCellTree(CellTree):
             super().is_branchable(branch_probability) &
             (self.cells['status'] == Status.HYPHAE)
         )
+
+
+@attr.s(kw_only=True)
+class AfumigatusState(ModuleState):
+    tree = cell_tree(AfumigatusCellTree)
+
+
+class Afumigatus(Module):
+    name = 'afumigatus'
+    StateClass = AfumigatusState

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -1,0 +1,85 @@
+from enum import IntEnum
+
+import numpy as np
+
+from simulation.cell import CellArray, CellTree
+from simulation.coordinates import Point
+
+BOOLEAN_NETWORK_LENGTH = 23
+
+
+class Status(IntEnum):
+    RESTING_CONIDIA = 0
+    SWELLING_CONIDIA = 1
+    HYPHAE = 2
+    DYING = 3
+    DEAD = 4
+
+
+class State(IntEnum):
+    FREE = 0
+    INTERNALIZING = 1
+    RELEASING = 2
+
+
+class AfumigatusCellArray(CellArray):
+    AFUMIGATUS_FIELDS = [
+        ('boolean_network', 'b1', BOOLEAN_NETWORK_LENGTH),
+        ('state', 'u1'),
+        ('status', 'u1'),
+        ('iron_pool', 'f8'),
+        ('iron', 'b1'),
+        ('iteration', 'i4')
+    ]
+
+    dtype = np.dtype(CellArray.BASE_FIELDS + AFUMIGATUS_FIELDS, align=True)  # type: ignore
+
+    @classmethod
+    def create_cell(cls, point: Point = None, iron_pool: float = 0,
+                    status: Status = Status.RESTING_CONIDIA,
+                    state: State = State.FREE, **kwargs) -> np.record:
+
+        if point is None:
+            point = Point()
+
+        growth = cls.GROWTH_SCALE_FACTOR * Point.from_array(2 * np.random.rand(3) - 1)
+        network = cls.initial_boolean_network()
+        growable = True
+        switched = False
+        branchable = False
+        iteration = 0
+        iron = False
+
+        return np.rec.array([
+            (point, growth, growable, switched, branchable,
+             network, state, status, iron_pool, iron, iteration)
+        ], dtype=cls.dtype)[0]
+
+    @classmethod
+    def initial_boolean_network(cls) -> np.ndarray:
+        return np.asarray([
+            True, False, True, False, True, True, True, True, True, False, False, False,
+            True, False, False, False, False, False, False, False, False, False, False
+        ])
+
+
+class AfumigatusCellTree(CellTree):
+    CellArrayClass = AfumigatusCellArray
+
+    def append(self, cell, parent=None):
+        if parent is not None:
+            iron_pool = self.cells[parent]['iron_pool'] / 2
+            self.cells[parent]['iron_pool'] = cell['iron_pool'] = iron_pool
+        return super().append(cell, parent)
+
+    def is_growable(self):
+        return (
+            super().is_growable() &
+            (self.cells['status'] == Status.HYPHAE)
+        )
+
+    def is_branchable(self, branch_probability):
+        return (
+            super().is_branchable(branch_probability) &
+            (self.cells['status'] == Status.HYPHAE)
+        )

--- a/simulation/state.py
+++ b/simulation/state.py
@@ -2,7 +2,7 @@ from functools import reduce
 from io import BytesIO
 from pathlib import PurePath
 from tempfile import NamedTemporaryFile
-from typing import Any, cast, Dict, IO, List, Tuple, TYPE_CHECKING, Union
+from typing import Any, cast, Dict, IO, List, Tuple, Type, TYPE_CHECKING, Union
 
 import attr
 from h5py import File as H5File
@@ -11,6 +11,7 @@ import numpy as np
 from simulation.validation import context as validation_context
 
 if TYPE_CHECKING:  # prevent circular imports for type checking
+    from simulation.cell import CellTree
     from simulation.config import SimulationConfig  # noqa
     from simulation.module import ModuleState  # noqa
 
@@ -244,3 +245,13 @@ def grid_variable(dtype: np.dtype = np.dtype('float')) -> np.ndarray:
     }
     return attr.ib(default=attr.Factory(factory, takes_self=True),
                    validator=validate_numeric, metadata=metadata)
+
+
+def cell_tree(tree_class: Type['CellTree']) -> 'CellTree':
+    def factory(self: 'ModuleState'):
+        return tree_class(grid=self.global_state.grid)
+
+    metadata = {
+        'cell_tree': True
+    }
+    return attr.ib(default=attr.Factory(factory, takes_self=True), metadata=metadata)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,8 @@
 from pytest import fixture
 
 from simulation.config import SimulationConfig
-from simulation.state import State
+from simulation.coordinates import Point
+from simulation.state import RectangularGrid, State
 
 
 @fixture
@@ -19,3 +20,14 @@ def config():
 @fixture
 def state(config):
     yield State.create(config)
+
+
+@fixture
+def grid():
+    # a 100 x 100 x 100 unit grid
+    yield RectangularGrid.construct_uniform((10, 10, 10), (10, 10, 10))
+
+
+@fixture
+def point():
+    yield Point(50, 50, 50)

--- a/test/test_afumigatus.py
+++ b/test/test_afumigatus.py
@@ -1,0 +1,24 @@
+from pytest import fixture
+
+from simulation.coordinates import Point
+from simulation.modules.afumigatus import AfumigatusCellTree, Status
+from simulation.state import RectangularGrid
+
+
+@fixture
+def cell_tree(grid: RectangularGrid, point: Point):
+    tree = AfumigatusCellTree.create_from_seed(grid=grid, point=point, status=Status.HYPHAE)
+    yield tree
+
+
+def test_split_iron_pool(cell_tree: AfumigatusCellTree):
+    cell_tree.cells['iron_pool'] = 1
+
+    cell_tree.elongate()
+    assert len(cell_tree) == 2
+
+    cell_tree.cells['status'] = Status.HYPHAE
+
+    cell_tree.branch(1)
+    assert len(cell_tree) == 3
+    assert (cell_tree.cells['iron_pool'] == [0.25, 0.5, 0.25]).all()

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -1,6 +1,8 @@
+from typing import Set
+
 from pytest import fixture
 
-from simulation.cell import CellArray
+from simulation.cell import CellArray, CellTree, Status
 from simulation.coordinates import Point
 from simulation.state import RectangularGrid
 
@@ -12,22 +14,69 @@ def grid():
 
 
 @fixture
-def cell_tree(grid: RectangularGrid):
+def point():
+    yield Point(50, 50, 50)
+
+
+@fixture
+def cells(grid: RectangularGrid, point: Point):
     # a single cell in the middle of the domain
-    tree = CellArray(1, point=Point(50, 50, 50))
-    tree['status'] = tree.Status.HYPHAE
+    cell = CellArray.create_cell(point=point)
+    cells = CellArray([cell])
+    cells['status'] = Status.HYPHAE
+    yield cells
+
+
+@fixture
+def cell_tree(grid: RectangularGrid, point: Point):
+    tree = CellTree.create_from_seed(grid=grid, point=point)
+    tree.cells['status'] = Status.HYPHAE
     yield tree
 
 
-def test_initial_attributes(cell_tree: CellArray):
-    cell = cell_tree[0]
+@fixture
+def populated_tree(cell_tree: CellTree, point: Point):
+    """Return a non-trivial cell tree."""
+    # TODO: use valid locations
+    cell_tree[0]['growable'] = False
+    cell_tree[0]['branchable'] = False
+    for _ in range(5):
+        cell = CellArray.create_cell(point=point)
+        cell['status'] = Status.HYPHAE
+        cell['growable'] = True
+        cell['branchable'] = True
+        cell_tree.append(cell, parent=0)
+
+    for i in [2, 3]:
+        cell_tree[i]['growable'] = False
+        cell_tree[i]['branchable'] = False
+        for _ in range(2 * i):
+            cell = CellArray.create_cell(point=point)
+            cell['growable'] = True
+            cell['branchable'] = True
+            cell_tree.append(cell, parent=i)
+
+    for i in [4, 10]:
+        cell_tree[i]['growable'] = False
+        cell_tree[i]['branchable'] = False
+
+        cell = CellArray.create_cell(point=point)
+        cell['growable'] = True
+        cell['branchable'] = True
+        cell_tree.append(cell, parent=i)
+
+    yield cell_tree
+
+
+def test_initial_attributes(cells: CellArray):
+    cell = cells[0]
     assert cell['growable']
     assert not cell['branchable']
 
 
-def test_branched_attributes(grid: RectangularGrid, cell_tree: CellArray):
-    cell_tree['branchable'] = True
-    cell_tree = cell_tree.branch(1, grid)
+def test_branched_attributes(cell_tree: CellTree):
+    cell_tree.cells['branchable'] = True
+    cell_tree.branch(1)
 
     assert len(cell_tree) == 2
 
@@ -37,8 +86,8 @@ def test_branched_attributes(grid: RectangularGrid, cell_tree: CellArray):
     assert not cell_tree[1]['branchable']
 
 
-def test_elongated_attributes(grid: RectangularGrid, cell_tree: CellArray):
-    cell_tree = cell_tree.elongate(grid)
+def test_elongated_attributes(cell_tree: CellArray):
+    cell_tree.elongate()
 
     assert len(cell_tree) == 2
 
@@ -49,11 +98,31 @@ def test_elongated_attributes(grid: RectangularGrid, cell_tree: CellArray):
     assert not cell_tree[1]['branchable']
 
 
-def test_split_iron_pool(grid: RectangularGrid, cell_tree: CellArray):
-    cell_tree['iron_pool'] = 1
+def test_split_iron_pool(cell_tree: CellArray):
+    cell_tree.cells['iron_pool'] = 1
 
-    cell_tree = cell_tree.elongate(grid)
-    cell_tree = cell_tree.branch(1, grid)
+    cell_tree.elongate()
+    cell_tree.branch(1)
 
     assert len(cell_tree) == 3
-    assert (cell_tree['iron_pool'] == [0.25, 0.5, 0.25]).all()
+    assert (cell_tree.cells['iron_pool'] == [0.25, 0.5, 0.25]).all()
+
+
+def test_traverse_tree(populated_tree: CellTree):
+    visited: Set[int] = set()
+
+    def visit(root):
+        assert root.index not in visited
+        visited.add(root.index)
+        for child in root.children:
+            visit(child)
+
+    visit(populated_tree.root)
+    assert visited == set(range(len(populated_tree)))
+
+
+def test_mutate_cell(populated_tree: CellTree):
+    cell = populated_tree[4]
+    cell['iron_pool'] = 99
+
+    assert populated_tree.cells['iron_pool'][4] == 99

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -1,8 +1,8 @@
 from typing import Set
 
-from pytest import fixture
+from pytest import fixture, mark
 
-from simulation.cell import CellArray, CellTree, Status
+from simulation.cell import CellArray, CellTree
 from simulation.coordinates import Point
 from simulation.state import RectangularGrid
 
@@ -23,14 +23,12 @@ def cells(grid: RectangularGrid, point: Point):
     # a single cell in the middle of the domain
     cell = CellArray.create_cell(point=point)
     cells = CellArray([cell])
-    cells['status'] = Status.HYPHAE
     yield cells
 
 
 @fixture
 def cell_tree(grid: RectangularGrid, point: Point):
     tree = CellTree.create_from_seed(grid=grid, point=point)
-    tree.cells['status'] = Status.HYPHAE
     yield tree
 
 
@@ -42,7 +40,6 @@ def populated_tree(cell_tree: CellTree, point: Point):
     cell_tree[0]['branchable'] = False
     for _ in range(5):
         cell = CellArray.create_cell(point=point)
-        cell['status'] = Status.HYPHAE
         cell['growable'] = True
         cell['branchable'] = True
         cell_tree.append(cell, parent=0)
@@ -98,6 +95,7 @@ def test_elongated_attributes(cell_tree: CellArray):
     assert not cell_tree[1]['branchable']
 
 
+@mark.skip('Move to module')
 def test_split_iron_pool(cell_tree: CellArray):
     cell_tree.cells['iron_pool'] = 1
 
@@ -123,6 +121,7 @@ def test_traverse_tree(populated_tree: CellTree):
 
 def test_mutate_cell(populated_tree: CellTree):
     cell = populated_tree[4]
-    cell['iron_pool'] = 99
+    growable = not cell['growable']
+    cell['growable'] = growable
 
-    assert populated_tree.cells['iron_pool'][4] == 99
+    assert populated_tree.cells['growable'][4] == growable

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -1,21 +1,10 @@
 from typing import Set
 
-from pytest import fixture, mark
+from pytest import fixture
 
 from simulation.cell import CellArray, CellTree
 from simulation.coordinates import Point
 from simulation.state import RectangularGrid
-
-
-@fixture
-def grid():
-    # a 100 x 100 x 100 unit grid
-    yield RectangularGrid.construct_uniform((10, 10, 10), (10, 10, 10))
-
-
-@fixture
-def point():
-    yield Point(50, 50, 50)
 
 
 @fixture
@@ -93,17 +82,6 @@ def test_elongated_attributes(cell_tree: CellArray):
 
     assert cell_tree[1]['growable']
     assert not cell_tree[1]['branchable']
-
-
-@mark.skip('Move to module')
-def test_split_iron_pool(cell_tree: CellArray):
-    cell_tree.cells['iron_pool'] = 1
-
-    cell_tree.elongate()
-    cell_tree.branch(1)
-
-    assert len(cell_tree) == 3
-    assert (cell_tree.cells['iron_pool'] == [0.25, 0.5, 0.25]).all()
 
 
 def test_traverse_tree(populated_tree: CellTree):

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -1,6 +1,6 @@
 from pytest import fixture
 
-from simulation.cell import CellTree
+from simulation.cell import CellArray
 from simulation.coordinates import Point
 from simulation.state import RectangularGrid
 
@@ -14,18 +14,18 @@ def grid():
 @fixture
 def cell_tree(grid: RectangularGrid):
     # a single cell in the middle of the domain
-    tree = CellTree(1, point=Point(50, 50, 50))
+    tree = CellArray(1, point=Point(50, 50, 50))
     tree['status'] = tree.Status.HYPHAE
     yield tree
 
 
-def test_initial_attributes(cell_tree: CellTree):
+def test_initial_attributes(cell_tree: CellArray):
     cell = cell_tree[0]
     assert cell['growable']
     assert not cell['branchable']
 
 
-def test_branched_attributes(grid: RectangularGrid, cell_tree: CellTree):
+def test_branched_attributes(grid: RectangularGrid, cell_tree: CellArray):
     cell_tree['branchable'] = True
     cell_tree = cell_tree.branch(1, grid)
 
@@ -37,7 +37,7 @@ def test_branched_attributes(grid: RectangularGrid, cell_tree: CellTree):
     assert not cell_tree[1]['branchable']
 
 
-def test_elongated_attributes(grid: RectangularGrid, cell_tree: CellTree):
+def test_elongated_attributes(grid: RectangularGrid, cell_tree: CellArray):
     cell_tree = cell_tree.elongate(grid)
 
     assert len(cell_tree) == 2
@@ -49,7 +49,7 @@ def test_elongated_attributes(grid: RectangularGrid, cell_tree: CellTree):
     assert not cell_tree[1]['branchable']
 
 
-def test_split_iron_pool(grid: RectangularGrid, cell_tree: CellTree):
+def test_split_iron_pool(grid: RectangularGrid, cell_tree: CellArray):
     cell_tree['iron_pool'] = 1
 
     cell_tree = cell_tree.elongate(grid)

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -1,0 +1,59 @@
+from pytest import fixture
+
+from simulation.cell import CellTree
+from simulation.coordinates import Point
+from simulation.state import RectangularGrid
+
+
+@fixture
+def grid():
+    # a 100 x 100 x 100 unit grid
+    yield RectangularGrid.construct_uniform((10, 10, 10), (10, 10, 10))
+
+
+@fixture
+def cell_tree(grid: RectangularGrid):
+    # a single cell in the middle of the domain
+    tree = CellTree(1, point=Point(50, 50, 50))
+    tree['status'] = tree.Status.HYPHAE
+    yield tree
+
+
+def test_initial_attributes(cell_tree: CellTree):
+    cell = cell_tree[0]
+    assert cell['growable']
+    assert not cell['branchable']
+
+
+def test_branched_attributes(grid: RectangularGrid, cell_tree: CellTree):
+    cell_tree['branchable'] = True
+    cell_tree = cell_tree.branch(1, grid)
+
+    assert len(cell_tree) == 2
+
+    assert not cell_tree[0]['branchable']
+
+    assert cell_tree[1]['growable']
+    assert not cell_tree[1]['branchable']
+
+
+def test_elongated_attributes(grid: RectangularGrid, cell_tree: CellTree):
+    cell_tree = cell_tree.elongate(grid)
+
+    assert len(cell_tree) == 2
+
+    assert not cell_tree[0]['growable']
+    assert cell_tree[0]['branchable']
+
+    assert cell_tree[1]['growable']
+    assert not cell_tree[1]['branchable']
+
+
+def test_split_iron_pool(grid: RectangularGrid, cell_tree: CellTree):
+    cell_tree['iron_pool'] = 1
+
+    cell_tree = cell_tree.elongate(grid)
+    cell_tree = cell_tree.branch(1, grid)
+
+    assert len(cell_tree) == 3
+    assert (cell_tree['iron_pool'] == [0.25, 0.5, 0.25]).all()


### PR DESCRIPTION
@jmasison01 

This implements some approximation of #15 using a slightly different approach.  I'm not yet sure if this is the best way to model the data or not.  For one, it may rely on too much numpy black magic to be comprehensible.  We will have to experiment a little to see if it will work.

These are the important details:
1. The primary data structure is called `CellTree`, but it is actually just a flat list of cells.  It will allow fast serialization and vectorized operations on independent cells.  Assuming the boolean network updates don't depend on each other, this will accelerate the simulation significantly.
2. There is no representation of the topology of the trees (e.g. the parent and children relationships).  There didn't seem to be any clear need given the logic of the previous implementation.  We can add the topological information via an adjacency matrix, but I'm curious if just an octree index would be more appropriate.  E.g. is it really the tree adjacency that is important, or the more general question of how many other cells are nearby?
3. Flattening out the data structure means that in order to do "in memory" elongation and branching, we need to pre-allocate a "maximum" number of cells during state creation because you can't expand a numpy array.  For now, the elongate and growth operations return a copy of the data (the old array + the new cells).
4. I managed to make the update work without adding any explicit loops which are generally slow in python.  I don't yet know if this is important and/or faster in this application.
5. This doesn't generalize the API around a cell.  The Afumigatus specific behavior will have to be extracted into a subclass.  I didn't know how other cell types would be different, so I didn't bother trying.