### PR TITLE
Move tree logic to afumigatus module

### DIFF
--- a/simulation/cell.py
+++ b/simulation/cell.py
@@ -106,7 +106,7 @@ class CellList(object):
         return cls(grid=grid, cell_data=cell_data)
 
     def append(self, cell: CellType) -> None:
-        if len(self) >= self.max_cells - 1:
+        if len(self) >= self.max_cells:
             raise Exception('Not enough free space in cell tree')
 
         index = self._ncells

--- a/simulation/cell.py
+++ b/simulation/cell.py
@@ -5,7 +5,7 @@ from h5py import Group
 import numpy as np
 
 from simulation.coordinates import Point
-from simulation.state import RectangularGrid, State
+from simulation.state import get_class_path, RectangularGrid, State
 
 MAX_CELL_LIST_SIZE = 10000
 
@@ -24,7 +24,7 @@ class CellData(np.ndarray):
     dtype = np.dtype(BASE_FIELDS, align=True)  # type: ignore
 
     def __new__(cls, arg: Union[int, Iterable[np.record]], initialize: bool = False, **kwargs):
-        if isinstance(arg, int):
+        if isinstance(arg, (int, np.int64, np.int32)):
             array = np.ndarray(shape=(arg,), dtype=cls.dtype).view(cls)
             if initialize:
                 for index in range(arg):
@@ -120,9 +120,8 @@ class CellList(object):
     def save(self, group: Group, name: str, metadata: dict) -> Group:
         composite_group = group.create_group(name)
 
-        class_ = self.__class__
         composite_group.attrs['type'] = 'CellList'
-        composite_group.attrs['class'] = f'{class_.__module__}:{class_.__name__}'
+        composite_group.attrs['class'] = get_class_path(self)
         composite_group.attrs['max_cells'] = self.max_cells
 
         composite_group.create_dataset(name='cell_data', data=self.cell_data)

--- a/simulation/module.py
+++ b/simulation/module.py
@@ -1,12 +1,10 @@
 from importlib import import_module
-from typing import Any, cast, Dict, Optional, Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 import attr
 from h5py import Dataset, Group
 import numpy as np
-from scipy.sparse import coo_matrix
 
-from simulation.cell import CellTree, MAX_CELL_TREE_SIZE
 from simulation.config import SimulationConfig
 from simulation.state import State
 
@@ -42,23 +40,44 @@ class ModuleState(object):
             name = field.name
             if name == 'global_state':
                 continue
-            metadata = field.metadata
-            if metadata.get('cell_tree'):
-                kwargs[name] = cls.load_cell_tree(global_state, group, name, metadata)
+            metadata = field.metadata or {}
+
+            group_object = group.get(name, None)
+            if group_object is None:
+                raise ValueError(f'Could not read {name} from file.')
+
+            if isinstance(group_object, Group):
+                # TODO: break this out into helper methods so subclasses can customize
+                class_name = group_object.attrs.get('class')
+                if class_name is None:
+                    raise ValueError(f'Field {name} contained an invalid composite type.')
+
+                module_name, class_name = class_name.split(':')
+                try:
+                    module = import_module(module_name)
+                except ImportError:
+                    raise TypeError(f'File references unknown module {module_name} in {name}')
+
+                class_ = getattr(module, class_name, None)
+                if class_ is None:
+                    raise TypeError(f'File references invalid class for {name}')
+
+                kwargs[name] = class_.load(global_state, group, name, metadata)
+
             else:
                 kwargs[name] = cls.load_attribute(global_state, group, name, metadata)
         return cls(**kwargs)
 
     @classmethod
     def save_attribute(
-        cls, group: Group, name: str, value: AttrValue, metadata: dict = None
+        cls, group: Group, name: str, value: AttrValue, metadata: dict
     ) -> Union[Dataset, Group]:
         """Save an attribute into an HDF5 group."""
         metadata = metadata or {}
         if isinstance(value, (float, int, str, bool, np.ndarray)):
             return cls.save_simple_type(group, name, value, metadata)
-        elif isinstance(value, CellTree):
-            return cls.save_cell_tree(group, name, value, metadata)
+        elif hasattr(value, 'save'):
+            return value.save(group, name, metadata)
         else:
             # modules must define serializers for unsupported types
             raise TypeError(f'Attribute {name} in {group.name} contains an unsupported datatype.')
@@ -87,23 +106,6 @@ class ModuleState(object):
         return var
 
     @classmethod
-    def save_cell_tree(cls, group: Group, name: str, value: CellTree, metadata: dict) -> Group:
-        composite_group = group.create_group(name)
-
-        class_ = value.__class__
-        composite_group.attrs['type'] = 'CellTree'
-        composite_group.attrs['class'] = f'{class_.__module__}:{class_.__name__}'
-        composite_group.attrs['max_size'] = value.max_cells
-
-        composite_group.create_dataset(name='cells', data=value.cells)
-
-        sp = value.adjacency.tocoo()
-        composite_group.create_dataset(name='row', data=sp.row)
-        composite_group.create_dataset(name='col', data=sp.col)
-        composite_group.create_dataset(name='value', data=sp.data)
-        return composite_group
-
-    @classmethod
     def load_attribute(
         cls, global_state: State, group: Group, name: str, metadata: Optional[dict] = None
     ) -> AttrValue:
@@ -114,37 +116,6 @@ class ModuleState(object):
         else:
             value = dataset[:]
         return value
-
-    @classmethod
-    def load_cell_tree(
-        cls, global_state: State, group: Group, name: str, metadata: Optional[dict] = None
-    ) -> CellTree:
-        composite_dataset = group[name]
-
-        attrs = composite_dataset.attrs
-        if attrs.get('type') != 'CellTree' or attrs.get('class') is None:
-            raise TypeError(f'File contains invalid type for {name}')
-
-        module_name, class_name = attrs['class'].split(':')
-        try:
-            module = import_module(module_name)
-        except ImportError:
-            raise TypeError(f'File references unknown module {module_name} in {name}')
-
-        class_ = getattr(module, class_name, None)
-        if class_ is None:
-            raise TypeError(f'File references invalid class for {name}')
-
-        class_ = cast(Type[CellTree], class_)
-        max_size = attrs.get('max_size', MAX_CELL_TREE_SIZE)
-
-        adjacency = coo_matrix(
-            (composite_dataset['value'], (composite_dataset['row'], composite_dataset['col'])),
-            shape=(max_size, max_size),
-        ).todok()
-        cells = composite_dataset['cells'][:].view(class_.CellArrayClass)
-
-        return class_(grid=global_state.grid, cells=cells, adjacency=adjacency)
 
 
 class Module(object):

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -1,33 +1,40 @@
+from collections.abc import MutableMapping
 from enum import IntEnum
+from typing import Iterable, List, Optional, Union
 
 import attr
+from h5py import Group
 import numpy as np
+from scipy.sparse import coo_matrix, dok_matrix as sparse_matrix
+from scipy.spatial.transform import Rotation
 
-from simulation.cell import CellArray, CellTree
+from simulation.cell import CellData, CellList, CellType
 from simulation.coordinates import Point
 from simulation.module import Module, ModuleState
-from simulation.state import cell_tree
-
-BOOLEAN_NETWORK_LENGTH = 23
+from simulation.state import RectangularGrid, State
 
 
-class Status(IntEnum):
-    RESTING_CONIDIA = 0
-    SWELLING_CONIDIA = 1
-    HYPHAE = 2
-    DYING = 3
-    DEAD = 4
+class AfumigatusCellData(CellData):
+    BOOLEAN_NETWORK_LENGTH = 23
 
+    class Status(IntEnum):
+        RESTING_CONIDIA = 0
+        SWELLING_CONIDIA = 1
+        HYPHAE = 2
+        DYING = 3
+        DEAD = 4
 
-class State(IntEnum):
-    FREE = 0
-    INTERNALIZING = 1
-    RELEASING = 2
+    class State(IntEnum):
+        FREE = 0
+        INTERNALIZING = 1
+        RELEASING = 2
 
-
-class AfumigatusCellArray(CellArray):
     AFUMIGATUS_FIELDS = [
         ('boolean_network', 'b1', BOOLEAN_NETWORK_LENGTH),
+        ('growth', Point.dtype),
+        ('growable', 'b1'),
+        ('switched', 'b1'),
+        ('branchable', 'b1'),
         ('state', 'u1'),
         ('status', 'u1'),
         ('iron_pool', 'f8'),
@@ -35,7 +42,7 @@ class AfumigatusCellArray(CellArray):
         ('iteration', 'i4'),
     ]
 
-    dtype = np.dtype(CellArray.BASE_FIELDS + AFUMIGATUS_FIELDS, align=True)  # type: ignore
+    dtype = np.dtype(CellData.BASE_FIELDS + AFUMIGATUS_FIELDS, align=True)  # type: ignore
 
     @classmethod
     def create_cell(
@@ -62,11 +69,11 @@ class AfumigatusCellArray(CellArray):
             [
                 (
                     point,
+                    network,
                     growth,
                     growable,
                     switched,
                     branchable,
-                    network,
                     state,
                     status,
                     iron_pool,
@@ -108,25 +115,251 @@ class AfumigatusCellArray(CellArray):
         )
 
 
-class AfumigatusCellTree(CellTree):
-    CellArrayClass = AfumigatusCellArray
+@attr.s(auto_attribs=True, kw_only=True, frozen=True)
+class AfumigatusCell(MutableMapping):
+    tree: 'AfumigatusCellTree'
+    index: int = attr.ib()
+
+    @index.validator
+    def _validate_index(self, attribute, value):
+        if value >= len(self.tree):
+            raise ValueError('Invalid cell index')
+
+    def __attrs_post_init__(self):
+        if self.index < 0:
+            object.__setattr__(self, 'index', self.index + len(self.tree))
+
+    @property
+    def record(self) -> CellType:
+        return self.tree.cells[self.index]
+
+    @property
+    def parent(self) -> Optional['AfumigatusCell']:
+        indices = self.tree.adjacency[:, self.index].nonzero()[0]
+        if len(indices) == 1:
+            return None
+        if len(indices) == 2 and indices[0] == self.index:
+            index = indices[0]
+            if index == self.index:
+                index = indices[1]
+            return self.__class__(tree=self.tree, index=index)
+
+        raise Exception(f'Invalid adjacency matrix at index {self.index}')
+
+    @property
+    def children(self) -> Iterable['AfumigatusCell']:
+        indices = self.tree.adjacency[self.index].nonzero()[1]
+        for index in indices:
+            if index != self.index:
+                yield self.__class__(tree=self.tree, index=index)
+
+    def add_child(self, cell: Union[CellType, 'AfumigatusCell']):
+        if isinstance(cell, AfumigatusCell):
+            cell = cell.record
+        self.tree.append(cell, parent=self.index)
+
+    def __getitem__(self, key):
+        return self.record.__getitem__(key)
+
+    def __setitem__(self, key, value):
+        self.tree.cell_data[key][self.index] = value
+
+    def __delitem__(self, key):
+        return self.record.__delitem__(key)
+
+    def __iter__(self):
+        for key in self.record.dtype.fields.keys():
+            yield key
+
+    def __contains__(self, key):
+        return key in self.record.dtype.fields
+
+    def __len__(self):
+        return len(self.record)
+
+
+@attr.s(kw_only=True, frozen=True, repr=False)
+class AfumigatusCellList(CellList):
+    CellDataClass = AfumigatusCellData
+
+
+@attr.s(kw_only=True, frozen=True, repr=False)
+class AfumigatusCellTree(object):
+    cells: CellList = attr.ib()
+    _adjacency: sparse_matrix = attr.ib()
+
+    @_adjacency.default
+    def __set_default_adjacency(self):
+        return sparse_matrix((0, 0))
+
+    def __attrs_post_init__(self):
+        cells = self.cells
+        adjacency = self._adjacency
+
+        object.__setattr__(self, '_adjacency', sparse_matrix((cells.max_cells, cells.max_cells)))
+
+        if len(cells) > 0:
+            for key, value in adjacency.items():
+                self._adjacency[key] = value
+
+    @property
+    def adjacency(self) -> sparse_matrix:
+        return self._adjacency[: len(self), : len(self)]
+
+    @property
+    def roots(self) -> List[CellType]:
+        if not len(self):
+            return []
+        # TODO: Return all roots
+        return [self[0]]
+
+    @property
+    def cell_data(self) -> AfumigatusCellData:
+        return self.cells.cell_data
+
+    @property
+    def max_cells(self) -> int:
+        return self.cells.max_cells
+
+    @property
+    def grid(self) -> RectangularGrid:
+        return self.cells.grid
+
+    @classmethod
+    def random_branch_direction(cls, growth: np.ndarray) -> np.ndarray:
+        """Rotate by a random 45 degree angle from the axis of growth."""
+        growth = Point.from_array(growth)
+
+        # get a random vector orthogonal to the growth vector
+        axis = Point.from_array(np.cross(growth, np.random.randn(3)))
+        axis = (np.pi / 4) * axis / axis.norm()
+
+        # rotate the growth vector 45 degrees along the random axis
+        rotation = Rotation.from_rotvec(axis)
+        return rotation.apply(growth)
+
+    @classmethod
+    def create_from_seed(cls, grid, **kwargs) -> 'AfumigatusCellTree':
+        cells = AfumigatusCellList.create_from_seed(grid, **kwargs)
+        adjacency = sparse_matrix((1, 1))
+        adjacency[0, 0] = 1
+
+        return cls(cells=cells, adjacency=adjacency)
+
+    def __len__(self):
+        return len(self.cells)
+
+    def __getitem__(self, index: int) -> AfumigatusCell:
+        if isinstance(index, str):
+            raise TypeError('Expected an integer index, did you mean `tree.cell_data[key]`?')
+        return AfumigatusCell(tree=self, index=index)
 
     def append(self, cell, parent=None):
+        index = len(self)
+        self.cells.append(cell)
+        self._adjacency[index, index] = 1
+
         if parent is not None:
+            self._adjacency[parent, index] = 1
             iron_pool = self.cells[parent]['iron_pool'] / 2
-            self.cells[parent]['iron_pool'] = cell['iron_pool'] = iron_pool
-        return super().append(cell, parent)
+            self.cells[parent]['iron_pool'] = self.cells[-1]['iron_pool'] = iron_pool
 
-    def is_growable(self):
-        return super().is_growable() & (self.cells['status'] == Status.HYPHAE)
+    def extend(self, cells: CellData, parents: Iterable[Union[int, None]] = None) -> None:
+        if parents is None:
+            parents = [None] * len(cells)
 
-    def is_branchable(self, branch_probability):
-        return super().is_branchable(branch_probability) & (self.cells['status'] == Status.HYPHAE)
+        for cell, parent in zip(cells, parents):
+            self.append(cell, parent)
+
+    def is_growable(self) -> np.ndarray:
+        cells = self.cells.cell_data
+        return (
+            cells['growable']
+            & cells.point_mask(cells['point'] + cells['growth'], self.grid)
+            & (cells['status'] == AfumigatusCellData.Status.HYPHAE)
+        )
+
+    def is_branchable(self, branch_probability: float) -> np.ndarray:
+        cells = self.cells.cell_data
+        return (
+            cells['branchable']
+            & (np.random.rand(*cells.shape) < branch_probability)
+            & (cells['status'] == AfumigatusCellData.Status.HYPHAE)
+        )
+
+    def elongate(self):
+        cells = self.cell_data
+        mask = self.is_growable().nonzero()[0]
+        if len(mask) == 0:
+            return
+
+        cells['growable'][mask] = False
+        cells['branchable'][mask] = True
+
+        children = AfumigatusCellData(len(mask), initialize=True)
+        children['point'] = cells['point'][mask] + cells['growth'][mask]
+        children['growth'] = cells['growth'][mask]
+
+        self.extend(children, parents=mask)
+
+    def branch(self, branch_probability: float):
+        cells = self.cell_data
+        indices = self.is_branchable(branch_probability).nonzero()[0]
+        if len(indices) == 0:
+            return
+
+        children = AfumigatusCellData(len(indices), initialize=True)
+        children['growth'] = np.apply_along_axis(
+            self.random_branch_direction, 1, children['growth']
+        )
+
+        children['point'] = cells['point'][indices] + children['growth']
+
+        # filter out children lying outside of the domain
+        indices = indices[cells.point_mask(children['point'], self.grid)]
+        if len(indices) == 0:
+            return
+
+        # set properties
+        cells['branchable'][indices] = False
+        children['growable'] = True
+        children['branchable'] = False
+
+        self.extend(children, parents=indices)
+
+    def save(self, group: Group, name: str, metadata: dict) -> Group:
+        composite_group = group.create_group(name)
+        composite_group['cells'] = self.cells.save(composite_group, 'cells', metadata)
+
+        sp = self.adjacency.tocoo()
+        composite_group.create_dataset(name='row', data=sp.row)
+        composite_group.create_dataset(name='col', data=sp.col)
+        composite_group.create_dataset(name='value', data=sp.data)
+        return composite_group
+
+    @classmethod
+    def load(
+        cls, global_state: State, group: Group, name: str, metadata: dict
+    ) -> 'AfumigatusCellTree':
+        composite_dataset = group[name]
+        cells = AfumigatusCellList.load(global_state, composite_dataset, name, metadata)
+
+        adjacency = coo_matrix(
+            (composite_dataset['value'], (composite_dataset['row'], composite_dataset['col'])),
+            shape=(cells.max_cells, cells.max_cells),
+        ).todok()
+
+        return cls(cells=cells, adjacency=adjacency)
+
+
+def cell_list_factory(self: 'AfumigatusState'):
+    cells = AfumigatusCellList(grid=self.global_state.grid)
+    return AfumigatusCellTree(cells=cells)
 
 
 @attr.s(kw_only=True)
 class AfumigatusState(ModuleState):
-    tree = cell_tree(AfumigatusCellTree)
+    tree: AfumigatusCellTree = attr.ib(default=attr.Factory(cell_list_factory, takes_self=True))
 
 
 class Afumigatus(Module):

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -11,7 +11,7 @@ from scipy.spatial.transform import Rotation
 from simulation.cell import CellData, CellList, CellType
 from simulation.coordinates import Point
 from simulation.module import Module, ModuleState
-from simulation.state import RectangularGrid, State
+from simulation.state import get_class_path, RectangularGrid, State
 
 
 class AfumigatusCellData(CellData):
@@ -329,7 +329,9 @@ class AfumigatusCellTree(object):
 
     def save(self, group: Group, name: str, metadata: dict) -> Group:
         composite_group = group.create_group(name)
-        composite_group['cells'] = self.cells.save(composite_group, 'cells', metadata)
+        composite_group.attrs['class'] = get_class_path(self)
+        composite_group.attrs['type'] = 'CellTree'
+        self.cells.save(composite_group, 'cells', metadata)
 
         sp = self.adjacency.tocoo()
         composite_group.create_dataset(name='row', data=sp.row)
@@ -342,7 +344,7 @@ class AfumigatusCellTree(object):
         cls, global_state: State, group: Group, name: str, metadata: dict
     ) -> 'AfumigatusCellTree':
         composite_dataset = group[name]
-        cells = AfumigatusCellList.load(global_state, composite_dataset, name, metadata)
+        cells = AfumigatusCellList.load(global_state, composite_dataset, 'cells', metadata)
 
         adjacency = coo_matrix(
             (composite_dataset['value'], (composite_dataset['row'], composite_dataset['col'])),

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -15,6 +15,7 @@ from simulation.state import get_class_path, RectangularGrid, State
 
 
 class AfumigatusCellData(CellData):
+    GROWTH_SCALE_FACTOR = 0.02  # from original code
     BOOLEAN_NETWORK_LENGTH = 23
 
     class Status(IntEnum):

--- a/simulation/state.py
+++ b/simulation/state.py
@@ -257,3 +257,8 @@ def cell_list(list_class: Type['CellList']) -> 'CellList':
 
     metadata = {'cell_list': True}
     return attr.ib(default=attr.Factory(factory, takes_self=True), metadata=metadata)
+
+
+def get_class_path(instance: Any) -> str:
+    class_ = instance.__class__
+    return f'{class_.__module__}:{class_.__name__}'

--- a/simulation/state.py
+++ b/simulation/state.py
@@ -11,7 +11,7 @@ import numpy as np
 from simulation.validation import context as validation_context
 
 if TYPE_CHECKING:  # prevent circular imports for type checking
-    from simulation.cell import CellTree
+    from simulation.cell import CellList
     from simulation.config import SimulationConfig  # noqa
     from simulation.module import ModuleState  # noqa
 
@@ -251,9 +251,9 @@ def grid_variable(dtype: np.dtype = _dtype_float) -> np.ndarray:
     )
 
 
-def cell_tree(tree_class: Type['CellTree']) -> 'CellTree':
+def cell_list(list_class: Type['CellList']) -> 'CellList':
     def factory(self: 'ModuleState'):
-        return tree_class(grid=self.global_state.grid)
+        return list_class(grid=self.global_state.grid)
 
-    metadata = {'cell_tree': True}
+    metadata = {'cell_list': True}
     return attr.ib(default=attr.Factory(factory, takes_self=True), metadata=metadata)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,6 @@
+from io import BytesIO
+
+from h5py import File
 from pytest import fixture
 
 from simulation.config import SimulationConfig
@@ -31,3 +34,13 @@ def grid():
 @fixture
 def point():
     yield Point(50, 50, 50)
+
+
+@fixture
+def hdf5_file():
+    yield File(BytesIO(), 'w')
+
+
+@fixture
+def hdf5_group(hdf5_file):
+    yield hdf5_file.create_group('test-group')

--- a/test/test_afumigatus.py
+++ b/test/test_afumigatus.py
@@ -1,8 +1,12 @@
+from typing import Set
+
 from pytest import fixture
 
 from simulation.coordinates import Point
-from simulation.modules.afumigatus import AfumigatusCellTree, Status
+from simulation.modules.afumigatus import AfumigatusCellData, AfumigatusCellTree
 from simulation.state import RectangularGrid
+
+Status = AfumigatusCellData.Status
 
 
 @fixture
@@ -11,43 +15,128 @@ def cell_tree(grid: RectangularGrid, point: Point):
     yield tree
 
 
+@fixture
+def populated_tree(cell_tree: AfumigatusCellTree, point: Point):
+    """Return a non-trivial cell tree."""
+    # TODO: use valid locations
+    cell_tree[0]['growable'] = False
+    cell_tree[0]['branchable'] = False
+    for _ in range(5):
+        cell = AfumigatusCellData.create_cell(point=point)
+        cell['growable'] = True
+        cell['branchable'] = True
+        cell_tree.append(cell, parent=0)
+
+    for i in [2, 3]:
+        cell_tree[i]['growable'] = False
+        cell_tree[i]['branchable'] = False
+        for _ in range(2 * i):
+            cell = AfumigatusCellData.create_cell(point=point)
+            cell['growable'] = True
+            cell['branchable'] = True
+            cell_tree.append(cell, parent=i)
+
+    for i in [4, 10]:
+        cell_tree[i]['growable'] = False
+        cell_tree[i]['branchable'] = False
+
+        cell = AfumigatusCellData.create_cell(point=point)
+        cell['growable'] = True
+        cell['branchable'] = True
+        cell_tree.append(cell, parent=i)
+
+    yield cell_tree
+
+
 def test_split_iron_pool(cell_tree: AfumigatusCellTree):
-    cell_tree.cells['iron_pool'] = 1
+    cell_tree.cell_data['iron_pool'] = 1
 
     cell_tree.elongate()
     assert len(cell_tree) == 2
 
-    cell_tree.cells['status'] = Status.HYPHAE
+    cell_tree.cell_data['status'] = Status.HYPHAE
 
     cell_tree.branch(1)
     assert len(cell_tree) == 3
-    assert (cell_tree.cells['iron_pool'] == [0.25, 0.5, 0.25]).all()
+    assert (cell_tree.cell_data['iron_pool'] == [0.25, 0.5, 0.25]).all()
 
 
 def test_elongate(cell_tree: AfumigatusCellTree):
-    cell_tree.cells['iron_pool'] = 1
+    cell_tree.cell_data['iron_pool'] = 1
     for _ in range(100):
-        cell_tree.cells['status'] = Status.HYPHAE
+        cell_tree.cell_data['status'] = Status.HYPHAE
         cell_tree.elongate()
 
     assert len(cell_tree) == 101
 
 
 def test_branch(cell_tree: AfumigatusCellTree):
-    cell_tree.cells['iron_pool'] = 1
-    cell_tree.cells['status'] = Status.HYPHAE
+    cell_tree.cell_data['iron_pool'] = 1
+    cell_tree.cell_data['status'] = Status.HYPHAE
     cell_tree.elongate()
 
-    cell_tree.cells['status'] = Status.HYPHAE
+    cell_tree.cell_data['status'] = Status.HYPHAE
     cell_tree.branch(1)
 
-    cell_tree.cells['status'] = Status.HYPHAE
+    cell_tree.cell_data['status'] = Status.HYPHAE
     cell_tree.elongate()
 
-    cell_tree.cells['status'] = Status.HYPHAE
+    cell_tree.cell_data['status'] = Status.HYPHAE
     cell_tree.elongate()
 
-    cell_tree.cells['status'] = Status.HYPHAE
+    cell_tree.cell_data['status'] = Status.HYPHAE
     cell_tree.branch(1)
 
     assert len(cell_tree) == 11
+
+
+def test_initial_attributes(point: Point):
+    cells = AfumigatusCellData([AfumigatusCellData.create_cell(point=point)])
+    cell = cells[0]
+    assert cell['growable']
+    assert not cell['branchable']
+
+
+def test_branched_attributes(cell_tree: AfumigatusCellTree):
+    cell_tree.cell_data['branchable'] = True
+    cell_tree.branch(1)
+
+    assert len(cell_tree) == 2
+
+    assert not cell_tree[0]['branchable']
+
+    assert cell_tree[1]['growable']
+    assert not cell_tree[1]['branchable']
+
+
+def test_elongated_attributes(cell_tree: AfumigatusCellData):
+    cell_tree.elongate()
+
+    assert len(cell_tree) == 2
+
+    assert not cell_tree[0]['growable']
+    assert cell_tree[0]['branchable']
+
+    assert cell_tree[1]['growable']
+    assert not cell_tree[1]['branchable']
+
+
+def test_traverse_tree(populated_tree: AfumigatusCellTree):
+    visited: Set[int] = set()
+
+    def visit(root):
+        assert root.index not in visited
+        visited.add(root.index)
+        for child in root.children:
+            visit(child)
+
+    visit(populated_tree.roots[0])
+    assert visited == set(range(len(populated_tree)))
+
+
+def test_mutate_cell(populated_tree: AfumigatusCellTree):
+    cell = populated_tree[4]
+    growable = not cell['growable']
+    cell['growable'] = growable
+
+    assert populated_tree.cell_data['growable'][4] == growable

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -1,8 +1,6 @@
-from typing import Set
-
 from pytest import fixture
 
-from simulation.cell import CellArray, CellTree
+from simulation.cell import CellData, CellList
 from simulation.coordinates import Point
 from simulation.state import RectangularGrid
 
@@ -10,96 +8,12 @@ from simulation.state import RectangularGrid
 @fixture
 def cells(grid: RectangularGrid, point: Point):
     # a single cell in the middle of the domain
-    cell = CellArray.create_cell(point=point)
-    cells = CellArray([cell])
+    cell = CellData.create_cell(point=point)
+    cells = CellData([cell])
     yield cells
 
 
 @fixture
-def cell_tree(grid: RectangularGrid, point: Point):
-    tree = CellTree.create_from_seed(grid=grid, point=point)
-    yield tree
-
-
-@fixture
-def populated_tree(cell_tree: CellTree, point: Point):
-    """Return a non-trivial cell tree."""
-    # TODO: use valid locations
-    cell_tree[0]['growable'] = False
-    cell_tree[0]['branchable'] = False
-    for _ in range(5):
-        cell = CellArray.create_cell(point=point)
-        cell['growable'] = True
-        cell['branchable'] = True
-        cell_tree.append(cell, parent=0)
-
-    for i in [2, 3]:
-        cell_tree[i]['growable'] = False
-        cell_tree[i]['branchable'] = False
-        for _ in range(2 * i):
-            cell = CellArray.create_cell(point=point)
-            cell['growable'] = True
-            cell['branchable'] = True
-            cell_tree.append(cell, parent=i)
-
-    for i in [4, 10]:
-        cell_tree[i]['growable'] = False
-        cell_tree[i]['branchable'] = False
-
-        cell = CellArray.create_cell(point=point)
-        cell['growable'] = True
-        cell['branchable'] = True
-        cell_tree.append(cell, parent=i)
-
-    yield cell_tree
-
-
-def test_initial_attributes(cells: CellArray):
-    cell = cells[0]
-    assert cell['growable']
-    assert not cell['branchable']
-
-
-def test_branched_attributes(cell_tree: CellTree):
-    cell_tree.cells['branchable'] = True
-    cell_tree.branch(1)
-
-    assert len(cell_tree) == 2
-
-    assert not cell_tree[0]['branchable']
-
-    assert cell_tree[1]['growable']
-    assert not cell_tree[1]['branchable']
-
-
-def test_elongated_attributes(cell_tree: CellArray):
-    cell_tree.elongate()
-
-    assert len(cell_tree) == 2
-
-    assert not cell_tree[0]['growable']
-    assert cell_tree[0]['branchable']
-
-    assert cell_tree[1]['growable']
-    assert not cell_tree[1]['branchable']
-
-
-def test_traverse_tree(populated_tree: CellTree):
-    visited: Set[int] = set()
-
-    def visit(root):
-        assert root.index not in visited
-        visited.add(root.index)
-        for child in root.children:
-            visit(child)
-
-    visit(populated_tree.root)
-    assert visited == set(range(len(populated_tree)))
-
-
-def test_mutate_cell(populated_tree: CellTree):
-    cell = populated_tree[4]
-    growable = not cell['growable']
-    cell['growable'] = growable
-
-    assert populated_tree.cells['growable'][4] == growable
+def cell_list(grid: RectangularGrid, point: Point):
+    cells = CellList.create_from_seed(grid=grid, point=point)
+    yield cells

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -1,4 +1,5 @@
-from pytest import fixture
+from h5py import Group
+from pytest import fixture, raises
 
 from simulation.cell import CellData, CellList
 from simulation.coordinates import Point
@@ -6,7 +7,7 @@ from simulation.state import RectangularGrid
 
 
 @fixture
-def cells(grid: RectangularGrid, point: Point):
+def cell(grid: RectangularGrid, point: Point):
     # a single cell in the middle of the domain
     cell = CellData.create_cell(point=point)
     cells = CellData([cell])
@@ -17,3 +18,41 @@ def cells(grid: RectangularGrid, point: Point):
 def cell_list(grid: RectangularGrid, point: Point):
     cells = CellList.create_from_seed(grid=grid, point=point)
     yield cells
+
+
+def test_append_cell_list(cell, cell_list):
+    original_length = len(cell_list)
+    cell_list.append(cell)
+    assert len(cell_list) == original_length + 1
+    assert cell == cell_list[-1]
+
+
+def test_extend_cell_list(cell, cell_list):
+    original_length = len(cell_list)
+    cell_list.extend([cell, cell])
+    assert len(cell_list) == original_length + 2
+    assert cell == cell_list[-1]
+    assert cell == cell_list[-2]
+
+
+def test_serialize(cell_list: CellList, hdf5_group: Group):
+    cell_list_group = cell_list.save(hdf5_group, 'test', {})
+    assert cell_list_group['cell_data'].shape == (len(cell_list),)
+    assert cell_list_group['cell_data'].dtype == cell_list.cell_data.dtype
+
+
+def test_get_cell(cell_list: CellList):
+    assert cell_list[0] == cell_list.cell_data[0]
+
+
+def test_getitem_error(cell_list: CellList):
+    with raises(TypeError):
+        _ = cell_list['a']  # type: ignore
+
+
+def test_out_of_memory_error(grid: RectangularGrid, cell: CellData):
+    cell_list = CellList(grid=grid, max_cells=1)
+    cell_list.append(cell)
+
+    with raises(Exception):
+        cell_list.append(cell)


### PR DESCRIPTION
This is a largish refactor, so I'm giving some heads up.  I still need to add testing to make sure it's actually working and some docstrings.

The upshot is that the generic user-level cell class is now `CellList`.  The `CellTree` specific logic is moved to the afumigatus module.  