### PR TITLE
Add a voxel index to the CellList class

### DIFF
--- a/simulation/coordinates.py
+++ b/simulation/coordinates.py
@@ -1,18 +1,17 @@
 import numpy as np
 
 
-class Point(np.ndarray):
-    """An array subclass representing a point or vector in 3D space."""
+class Coordinate(np.ndarray):
+    def __new__(cls, *, x: float = 0, y: float = 0, z: float = 0) -> 'Coordinate':
+        return np.asarray([(z, y, x)], dtype=cls.dtype).reshape((3,)).view(cls)
 
-    dtype = np.dtype((np.dtype('<f8'), (3,)))
-
-    def __new__(cls, x: float = 0, y: float = 0, z: float = 0) -> 'Point':
-        return np.asarray([z, y, x], dtype=np.float64).view(cls)
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.x}, {self.y}, {self.z})'
 
     @classmethod
-    def from_array(cls, array: np.ndarray) -> 'Point':
+    def from_array(cls, array: np.ndarray) -> 'Coordinate':
         if array.shape != (3,):
-            raise ValueError('Invalid shape for point object')
+            raise ValueError('Invalid shape for a coordinate object')
         return array.view(cls)
 
     @property
@@ -41,3 +40,27 @@ class Point(np.ndarray):
 
     def norm(self, ord: float = 2):
         return np.linalg.norm(self, ord=ord)
+
+
+class Point(Coordinate):
+    """An array subclass representing a point or vector in 3D space."""
+
+    dtype = np.dtype((np.dtype('<f8'), (3,)))
+
+
+class Voxel(Coordinate):
+    """An array subclass representing the coordinates of a voxel in a 3D array."""
+
+    dtype = np.dtype((np.dtype('i4'), (3,)))
+
+    def __hash__(self):
+        return hash(','.join([str(i) for i in self]))
+
+    def __eq__(self, other):
+        value = super().__eq__(other)
+        if isinstance(value, np.ndarray):
+            value = value.all()
+        return value
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,7 +33,7 @@ def grid():
 
 @fixture
 def point():
-    yield Point(50, 50, 50)
+    yield Point(x=50, y=50, z=50)
 
 
 @fixture

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_equal
 from pytest import fixture, raises
 
 from simulation.cell import CellData, CellList
-from simulation.coordinates import Point
+from simulation.coordinates import Point, Voxel
 from simulation.state import RectangularGrid
 
 
@@ -69,3 +69,40 @@ def test_filter_out_dead(grid: RectangularGrid):
 
     mask = np.arange(10) < 5
     assert_array_equal(cells.alive(mask), [0, 2, 4])
+
+
+def test_get_neighboring_cells(grid: RectangularGrid):
+    point = Point(x=4.5, y=4.5, z=4.5)
+
+    raw_cells = [CellData.create_cell(point=point) for _ in range(5)]
+    raw_cells[1]['point'] = Point(x=-1, y=4.5, z=4.5)
+    raw_cells[4]['point'] = Point(x=4.5, y=4.5, z=-1)
+
+    cells = CellList(grid=grid)
+    cells.extend(raw_cells)
+
+    assert_array_equal(cells.get_neighboring_cells(cells[0]), [0, 2, 3])
+    assert_array_equal(cells.get_cells_in_voxel(Voxel(x=0, y=0, z=0)), [])
+
+
+def test_move_cell(grid: RectangularGrid):
+    point = Point(x=4.5, y=4.5, z=4.5)
+
+    raw_cells = [CellData.create_cell(point=point) for _ in range(5)]
+    raw_cells[1]['point'] = Point(x=-1, y=4.5, z=4.5)
+    raw_cells[4]['point'] = Point(x=4.5, y=4.5, z=-1)
+
+    cells = CellList(grid=grid)
+    cells.extend(raw_cells)
+
+    cells[0]['point'] = Point(x=50, y=50, z=50)
+
+    # updating an incorrect index will not update the cell at index 0
+    cells.update_voxel_index([1, 3])
+    assert_array_equal(cells.get_neighboring_cells(cells[2]), [0, 2, 3])
+    assert cells._reverse_voxel_index[0] == grid.get_voxel(point)
+
+    # this should correctly update the voxel index
+    cells.update_voxel_index([0])
+    assert_array_equal(cells.get_neighboring_cells(cells[0]), [0])
+    assert cells._reverse_voxel_index[0] == grid.get_voxel(cells[0]['point'])


### PR DESCRIPTION
This index allows efficient lookup for cells that exist inside a single voxel.  This also adds a simple API for listing cells inside a voxel, or alternatively the same voxel as another cell.