### PR TITLE
Add methods on the grid to get neighboring voxels

### DIFF
--- a/simulation/cell.py
+++ b/simulation/cell.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Set, Type, Union
+from typing import Any, cast, Dict, Iterable, List, Set, Type, Union
 
 import attr
 from h5py import Group
@@ -66,6 +66,7 @@ class CellData(np.ndarray):
 
     def __new__(cls, arg: Union[int, Iterable[np.record]], initialize: bool = False, **kwargs):
         if isinstance(arg, (int, np.int64, np.int32)):
+            arg = cast(int, arg)
             array = np.ndarray(shape=(arg,), dtype=cls.dtype).view(cls)
             if initialize:
                 for index in range(arg):

--- a/simulation/coordinates.py
+++ b/simulation/coordinates.py
@@ -66,7 +66,7 @@ class Voxel(Coordinate):
     def __eq__(self, other):
         value = super().__eq__(other)
         if isinstance(value, np.ndarray):
-            value = value.all()
+            value = bool(value.all())
         return value
 
     def __ne__(self, other):

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -82,7 +82,7 @@ def test_get_neighboring_cells(grid: RectangularGrid):
     cells.extend(raw_cells)
 
     assert_array_equal(cells.get_neighboring_cells(cells[0]), [0, 2, 3])
-    assert_array_equal(cells.get_cells_in_voxel(Voxel(x=0, y=0, z=0)), [])
+    assert_array_equal(cells.get_cells_in_voxel(Voxel(x=0, y=0, z=0)), [0, 2, 3])
 
 
 def test_move_cell(grid: RectangularGrid):

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -1,0 +1,186 @@
+import pytest
+
+from simulation.coordinates import Point, Voxel
+from simulation.grid import RectangularGrid
+
+
+def v(x: int, y: int, z: int) -> Voxel:
+    return Voxel(x=x, y=y, z=z)
+
+
+def p(x: float, y: float, z: float) -> Point:
+    return Point(x=x, y=y, z=z)
+
+
+@pytest.fixture
+def grid():
+    shape = [10, 20, 30]
+    spacing = [1, 1, 1]
+    yield RectangularGrid.construct_uniform(shape=shape, spacing=spacing)
+
+
+@pytest.mark.parametrize(
+    'point,voxel',
+    [
+        (p(0.5, 0.5, 0.5), v(0, 0, 0)),
+        (p(1.5, 1.5, 1.5), v(1, 1, 1)),
+        (p(0.9, 0.9, 0.9), v(0, 0, 0)),
+        (p(1.9, 1.1, 0.1), v(1, 1, 0)),
+        (p(-0.1, -0.4, 0.4), v(-1, -1, 0)),
+    ],
+)
+def test_get_voxel(grid: RectangularGrid, point, voxel):
+    assert grid.get_voxel(point) == voxel
+
+
+@pytest.mark.parametrize(
+    'voxel,valid',
+    [
+        (v(0, 0, 0), True),
+        (v(9, 0, 4), True),
+        (v(-1, 0, 0), False),
+        (v(25, 0, 0), True),
+        (v(0, 0, 25), False),
+        (v(-1, -1, 100), False),
+    ],
+)
+def test_valid_voxel(grid: RectangularGrid, voxel, valid):
+    assert grid.is_valid_voxel(voxel) == valid
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    'voxel,neighbors',
+    [
+        (
+            v(5, 5, 5),
+            {
+                v(4, 5, 5),
+                v(6, 5, 5),
+                v(5, 4, 5),
+                v(5, 6, 5),
+                v(5, 5, 4),
+                v(5, 5, 6),
+            }
+        ),
+        (
+            v(0, 5, 5),
+            {
+                v(1, 5, 5),
+                v(0, 4, 5),
+                v(0, 6, 5),
+                v(0, 5, 4),
+                v(0, 5, 6),
+            }
+        ),
+        (
+            v(0, 0, 5),
+            {
+                v(1, 0, 5),
+                v(0, 1, 5),
+                v(0, 0, 4),
+                v(0, 0, 6),
+            }
+        ),
+        (
+            v(0, 0, 0),
+            {
+                v(1, 0, 0),
+                v(0, 1, 0),
+                v(0, 0, 1),
+            }
+        )
+    ]
+)
+# fmt: on
+def test_get_adjacent_voxels(grid: RectangularGrid, voxel, neighbors):
+    assert set(grid.get_adjecent_voxels(voxel)) == neighbors
+
+
+@pytest.mark.parametrize(
+    'point,in_domain',
+    [
+        (p(0.1, 0.1, 0.1), True),
+        (p(0, 0, 0), True),
+        (p(-1, 0, 0), False),
+        (p(100, 0, 0), False),
+        (p(100, 10, -100), False),
+    ]
+)
+def test_point_in_domain(grid, point, in_domain):
+    assert grid.is_point_in_domain(point) == in_domain
+
+
+@pytest.mark.parametrize(
+    'point,voxel',
+    [
+        (p(0.5, 0.5, 0.5), v(0, 0, 0)),
+        (p(1.5, 0.5, 0.5), v(1, 0, 0)),
+        (p(1.1, 5.5, 1.9), v(1, 5, 1)),
+    ]
+)
+def test_get_nearest_voxel(grid, point, voxel):
+    assert grid.get_nearest_voxel(point) == voxel
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    'point,distance,voxels',
+    [
+        (
+            p(5.5, 5.5, 5.5),
+            1,
+            {
+                (v(5, 5, 5), 0),
+                (v(4, 5, 5), 1),
+                (v(6, 5, 5), 1),
+                (v(5, 4, 5), 1),
+                (v(5, 6, 5), 1),
+                (v(5, 5, 4), 1),
+                (v(5, 5, 6), 1),
+            }
+        ),
+        (
+            p(0.5, 5.5, 5.5),
+            1,
+            {
+                (v(0, 5, 5), 0),
+                (v(1, 5, 5), 1),
+                (v(0, 4, 5), 1),
+                (v(0, 6, 5), 1),
+                (v(0, 5, 4), 1),
+                (v(0, 5, 6), 1),
+            }
+        ),
+        (
+            p(0.5, 0.5, 5.5),
+            1,
+            {
+                (v(0, 0, 5), 0),
+                (v(1, 0, 5), 1),
+                (v(0, 1, 5), 1),
+                (v(0, 0, 4), 1),
+                (v(0, 0, 6), 1),
+            }
+        ),
+        (
+            p(0.5, 0.5, 0.5),
+            1,
+            {
+                (v(0, 0, 0), 0),
+                (v(1, 0, 0), 1),
+                (v(0, 1, 0), 1),
+                (v(0, 0, 1), 1),
+            }
+        )
+    ]
+)
+# fmt: on
+def test_get_voxels_in_range(grid: RectangularGrid, point, distance, voxels):
+    assert set(grid.get_voxels_in_range(point, distance)) == voxels
+
+
+def test_get_voxels_in_large_range(grid: RectangularGrid):
+    for voxel, distance in grid.get_voxels_in_range(Point(x=4, y=4, z=4), 10):
+        assert distance <= 10
+        assert grid.is_valid_voxel(voxel)

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ show-source = True
 import-order-style = appnexus
 application-import-names = simulation
 ignore =
+    # missing whitespace after ',' (conflicts with black's formatting rules)
+    E231
     # closing bracket does not match indentation of opening bracket's line
     E123
     # whitespace before ':'


### PR DESCRIPTION
@jmasison01 This is meant to replace some of the logic in your modules where you are iterating over voxels near a point.

There is one difference in `get_adjecent_voxels` that we may need to go over.  In this implementation, I only return the six voxels that share a size rather than all 26 that touch on edges and corners as you are using in your code.  

I did this because it is more common in numerical simulations.  You are often modelling the flux between grid cells--those that don't share a side have no flux.  An alternative approach is to generate an empirical diffusion that will spread a quantity over some volume.  This would be appropriate in cases where the time steps are large.  In this case, you would want to use something like the `get_voxels_in_range` method.

It's simple to change the code here if necessary.  I just wanted to check the intent of the loops in your modules.