### PR TITLE
Switch all RNG to use a global Generator instance

### DIFF
--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -442,7 +442,7 @@ class Afumigatus(Module):
         #            cell['status'] = AfumigatusCellData.Status.DEAD
         #            cell['dead'] = True
         #        if tissue[vox.z, vox.y, vox.x] == TissueTypes.EPITHELIUM:
-        #            if afumigatus.p_lodge > random.random:
+        #            if afumigatus.p_lodge > rg.random():
         #                cell['mobile'] = False
         #    if cell['iteration'] >= afumigatus.ITER_TO_CHANGE_STATUS:
         #        if cell['status'] == AfumigatusCellData.Status.RESTING_CONIDIA:
@@ -450,7 +450,7 @@ class Afumigatus(Module):
         #        elif cell['status'] == AfumigatusCellData.Status.SWELLING_CONIDIA:
         #            cell['status'] = AfumigatusCellData.Status.GERMTUBE
         #        elif cell['status'] == AfumigatusCellData.Status.INTERNALIZED:
-        #            if afumigatus.p_internal_swell > random.random():
+        #            if afumigatus.p_internal_swell > rg.random():
         #                cell['status'] = AfumigatusCellData.Status.SWELLING_CONIDIA
         #
         #        if cell['status'] == AfumigatusCellData.Status.SWELLING_CONIDIA:

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -12,6 +12,7 @@ from simulation.cell import CellData, CellList, CellType
 from simulation.coordinates import Point
 from simulation.grid import RectangularGrid
 from simulation.module import Module, ModuleState
+from simulation.random import rg
 from simulation.state import get_class_path, State
 
 
@@ -61,7 +62,7 @@ class AfumigatusCellData(CellData):
         **kwargs,
     ) -> np.record:
 
-        growth = cls.GROWTH_SCALE_FACTOR * Point.from_array(2 * np.random.rand(3) - 1)
+        growth = cls.GROWTH_SCALE_FACTOR * Point.from_array(2 * rg.random(3) - 1)
         network = cls.initial_boolean_network()
         growable = True
         switched = False

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -321,7 +321,7 @@ class AfumigatusCellTreeList(object):
         """
         #  TODO: implement a real iron uptake model
         cells = self.cells.cell_data
-        iron = np.random.uniform(size=len(self.cells))
+        iron = rg.random(len(self.cells))
         cells['iron_pool'] = np.add(cells['iron_pool'], iron)
 
     def age(self):

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -241,7 +241,7 @@ class AfumigatusCellTreeList(object):
         growth = Point.from_array(growth)
 
         # get a random vector orthogonal to the growth vector
-        axis = Point.from_array(np.cross(growth, np.random.randn(3)))
+        axis = Point.from_array(np.cross(growth, rg.standard_normal(3)))
         axis = (np.pi / 4) * axis / axis.norm()
 
         # rotate the growth vector 45 degrees along the random axis

--- a/simulation/modules/afumigatus.py
+++ b/simulation/modules/afumigatus.py
@@ -310,7 +310,7 @@ class AfumigatusCellTreeList(object):
         cells = self.cells.cell_data
         return self.cells.alive(
             cells['branchable']
-            & (np.random.rand(*cells.shape) < branch_probability)
+            & (rg.random(cells.shape) < branch_probability)
             & (cells['status'] == AfumigatusCellData.Status.HYPHAE)
         )
 

--- a/simulation/modules/epithelium.py
+++ b/simulation/modules/epithelium.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-import random
 
 import attr
 import numpy as np
@@ -10,6 +9,7 @@ from simulation.grid import RectangularGrid
 from simulation.module import Module, ModuleState
 from simulation.modules.fungus import FungusCellData, FungusCellList
 from simulation.modules.geometry import TissueTypes
+from simulation.random import rg
 from simulation.state import State
 
 
@@ -107,7 +107,7 @@ class EpitheliumCellList(CellList):
                     if (
                         spores[index]['form'] == FungusCellData.Form.CONIDIA
                         and not spores[index]['internalized']
-                        and p_in > random.random()
+                        and p_in > rg.random()
                     ):
                         spores[index]['internalized'] = True
                         val = self.append_to_phagosome(i, index, max_spores)
@@ -138,7 +138,7 @@ class EpitheliumCellList(CellList):
                                     if (
                                         spores[index]['form'] == FungusCellData.Form.CONIDIA
                                         and not spores[index]['internalized']
-                                        and p_in > random.random()
+                                        and p_in > rg.random()
                                     ):
                                         spores[index]['internalized'] = True
                                         val = self.append_to_phagosome(i, index, max_spores)

--- a/simulation/modules/fungus.py
+++ b/simulation/modules/fungus.py
@@ -159,7 +159,7 @@ class FungusCellList(CellList):
         # grow hyphae
         if len(hyphae_indices) != 0:
             cells['status'][hyphae_indices] = FungusCellData.Status.GROWN
-            branch_mask = np.random.rand(len(hyphae_indices)) < p_branch
+            branch_mask = rg.random(len(hyphae_indices)) < p_branch
             not_branch_indices = (np.invert(branch_mask)).nonzero()[0]
             branch_indices = branch_mask.nonzero()[0]
 
@@ -218,7 +218,7 @@ class FungusCellList(CellList):
         ).nonzero()[0]
 
         # internal fungus with REST status
-        swall_mask = np.random.rand(len(internalized_rest_indices)) < p_internal_swell
+        swall_mask = rg.random(len(internalized_rest_indices)) < p_internal_swell
         internalized_rest_indices = swall_mask.nonzero()[0]
 
         cells['status'][internalized_rest_indices] = FungusCellData.Status.SWOLLEN

--- a/simulation/modules/fungus.py
+++ b/simulation/modules/fungus.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-import random
 
 import attr
 import numpy as np
@@ -8,6 +7,7 @@ from simulation.cell import CellData, CellList
 from simulation.coordinates import Point, Voxel
 from simulation.module import Module, ModuleState
 from simulation.modules.geometry import TissueTypes
+from simulation.random import rg
 from simulation.state import State
 
 
@@ -119,9 +119,9 @@ class FungusCellList(CellList):
             if len(indices) > 0:
                 np.random.shuffle(indices)
                 for i in range(init_num):
-                    x = random.uniform(grid.xv[indices[i][2]], grid.xv[indices[i][2] + 1])
-                    y = random.uniform(grid.yv[indices[i][1]], grid.yv[indices[i][1] + 1])
-                    z = random.uniform(grid.zv[indices[i][0]], grid.zv[indices[i][0] + 1])
+                    x = rg.uniform(grid.xv[indices[i][2]], grid.xv[indices[i][2] + 1])
+                    y = rg.uniform(grid.yv[indices[i][1]], grid.yv[indices[i][1] + 1])
+                    z = rg.uniform(grid.zv[indices[i][0]], grid.zv[indices[i][0] + 1])
 
                     point = Point(x=x, y=y, z=z)
                     points[i] = point

--- a/simulation/modules/fungus.py
+++ b/simulation/modules/fungus.py
@@ -117,7 +117,7 @@ class FungusCellList(CellList):
             points = np.zeros((init_num, 3))
             indices = np.argwhere(tissue == TissueTypes.EPITHELIUM.value)
             if len(indices) > 0:
-                np.random.shuffle(indices)
+                rg.shuffle(indices)
                 for i in range(init_num):
                     x = rg.uniform(grid.xv[indices[i][2]], grid.xv[indices[i][2] + 1])
                     y = rg.uniform(grid.yv[indices[i][1]], grid.yv[indices[i][1] + 1])

--- a/simulation/modules/fungus.py
+++ b/simulation/modules/fungus.py
@@ -152,7 +152,7 @@ class FungusCellList(CellList):
             cells['form'][conidia_indices] = FungusCellData.Form.HYPHAE
             children = FungusCellData(len(conidia_indices), initialize=True)
             children['iron'] = cells['iron'][conidia_indices]
-            growth = spacing * (np.random.rand(len(conidia_indices), 3) * 2 - 1)
+            growth = spacing * (rg.random((len(conidia_indices), 3)) * 2 - 1)
             children['point'] = cells['point'][conidia_indices] + growth
             self.spawn_hypahael_cell(children)
 
@@ -167,7 +167,7 @@ class FungusCellList(CellList):
             branch_children = FungusCellData(len(branch_indices), initialize=True)
 
             elongate_children['iron'] = cells['iron'][hyphae_indices] / 2
-            growth = spacing * (np.random.rand(len(hyphae_indices), 3) * 2 - 1)
+            growth = spacing * (rg.random((len(hyphae_indices), 3)) * 2 - 1)
             elongate_children['point'] = cells['point'][hyphae_indices] + growth
 
             if len(branch_indices) != 0:
@@ -176,7 +176,7 @@ class FungusCellList(CellList):
                 )
 
                 branch_children['iron'] = cells['iron'][hyphae_indices[branch_indices]] / 3
-                growth = spacing * (np.random.rand(len(hyphae_indices[branch_indices]), 3) * 2 - 1)
+                growth = spacing * (rg.random((len(hyphae_indices[branch_indices]), 3)) * 2 - 1)
                 branch_children['point'] = cells['point'][hyphae_indices[branch_indices]] + growth
 
             # update iron in orignal cells

--- a/simulation/modules/macrophage.py
+++ b/simulation/modules/macrophage.py
@@ -82,7 +82,7 @@ class MacrophageCellList(CellList):
         mask = cyto[blood_index[2], blood_index[1], blood_index[0]] >= rec_r
         blood_index = np.transpose(blood_index)
         cyto_index = blood_index[mask]
-        np.random.shuffle(cyto_index)
+        rg.shuffle(cyto_index)
 
         for _ in range(0, num_reps):
             if len(cyto_index) > 0:
@@ -175,7 +175,7 @@ class MacrophageCellList(CellList):
                 i = indices[0][0]
             elif num_vox_possible > 1:
                 inds = np.argwhere(p == p[np.argmax(p)])
-                np.random.shuffle(inds)
+                rg.shuffle(inds)
                 i = inds[0][0]
             else:
                 i = rg.integers(len(vox_list))

--- a/simulation/modules/macrophage.py
+++ b/simulation/modules/macrophage.py
@@ -9,6 +9,7 @@ from simulation.grid import RectangularGrid
 from simulation.module import Module, ModuleState
 from simulation.modules.fungus import FungusCellData, FungusCellList
 from simulation.modules.geometry import TissueTypes
+from simulation.random import rg
 from simulation.state import State
 
 MAX_CONIDIA = 100
@@ -94,7 +95,7 @@ class MacrophageCellList(CellList):
                     z=grid.z[cyto_index[ii][0]],
                 )
 
-                if p_rec_r > random.random():
+                if p_rec_r > rg.random():
                     self.append(MacrophageCellData.create_cell(point=point))
 
     def absorb_cytokines(self, m_abs, cyto, grid):
@@ -210,7 +211,7 @@ class MacrophageCellList(CellList):
                     if (
                         fungus[index]['form'] == FungusCellData.Form.CONIDIA
                         and not fungus[index]['internalized']
-                        and p_in > random.random()
+                        and p_in > rg.random()
                     ):
                         fungus[index]['internalized'] = True
                         self.append_to_phagosome(i, index, max_spores)
@@ -237,7 +238,7 @@ class MacrophageCellList(CellList):
                                     if (
                                         fungus[index]['form'] == FungusCellData.Form.CONIDIA
                                         and not fungus[index]['internalized']
-                                        and p_in > random.random()
+                                        and p_in > rg.random()
                                     ):
                                         fungus[index]['internalized'] = True
                                         self.append_to_phagosome(i, index, max_spores)

--- a/simulation/modules/macrophage.py
+++ b/simulation/modules/macrophage.py
@@ -1,5 +1,3 @@
-import random
-
 import attr
 import numpy as np
 
@@ -88,7 +86,7 @@ class MacrophageCellList(CellList):
 
         for _ in range(0, num_reps):
             if len(cyto_index) > 0:
-                ii = random.randint(0, len(cyto_index) - 1)
+                ii = rg.integers(len(cyto_index))
                 point = Point(
                     x=grid.x[cyto_index[ii][2]],
                     y=grid.y[cyto_index[ii][1]],
@@ -180,7 +178,7 @@ class MacrophageCellList(CellList):
                 np.random.shuffle(inds)
                 i = inds[0][0]
             else:
-                i = random.randint(0, len(vox_list) - 1)
+                i = rg.integers(len(vox_list))
 
             point = Point(
                 x=grid.x[vox.x + vox_list[i][0]],
@@ -259,7 +257,7 @@ class MacrophageCellList(CellList):
         if num == 0 and living_len > 0:
             num = 1
         for _ in range(num):
-            r = random.randint(0, living_len - 1)
+            r = rg.integers(living_len)
             self.cell_data[living[r]]['dead'] = True
 
 

--- a/simulation/modules/neutrophil.py
+++ b/simulation/modules/neutrophil.py
@@ -47,7 +47,7 @@ class NeutrophilCellList(CellList):
             mask = cyto[blood_index[2], blood_index[1], blood_index[0]] >= rec_r
             blood_index = np.transpose(blood_index)
             cyto_index = blood_index[mask]
-            np.random.shuffle(cyto_index)
+            rg.shuffle(cyto_index)
 
             for _ in range(0, num_reps):
                 if len(cyto_index) > 0:
@@ -145,7 +145,7 @@ class NeutrophilCellList(CellList):
                 i = indices[0][0]
             elif num_vox_possible > 1:
                 inds = np.argwhere(p == p[np.argmax(p)])
-                np.random.shuffle(inds)
+                rg.shuffle(inds)
                 i = inds[0][0]
             else:
                 i = rg.integers(len(vox_list))

--- a/simulation/modules/neutrophil.py
+++ b/simulation/modules/neutrophil.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-import random
 
 import attr
 import numpy as np
@@ -10,6 +9,7 @@ from simulation.grid import RectangularGrid
 from simulation.module import Module, ModuleState
 from simulation.modules.fungus import FungusCellData, FungusCellList
 from simulation.modules.geometry import TissueTypes
+from simulation.random import rg
 from simulation.state import State
 
 
@@ -51,7 +51,7 @@ class NeutrophilCellList(CellList):
 
             for _ in range(0, num_reps):
                 if len(cyto_index) > 0:
-                    ii = random.randint(0, len(cyto_index) - 1)
+                    ii = rg.integers(len(cyto_index))
                     point = Point(
                         x=grid.x[cyto_index[ii][2]],
                         y=grid.y[cyto_index[ii][1]],
@@ -148,7 +148,7 @@ class NeutrophilCellList(CellList):
                 np.random.shuffle(inds)
                 i = inds[0][0]
             else:
-                i = random.randint(0, len(vox_list) - 1)
+                i = rg.integers(len(vox_list))
 
             cell['point'] = Point(
                 x=grid.x[vox.x + vox_list[i][0]],

--- a/simulation/modules/phagocyte.py
+++ b/simulation/modules/phagocyte.py
@@ -9,6 +9,7 @@ from simulation.cell import CellData, CellList
 from simulation.coordinates import Point, Voxel
 from simulation.grid import RectangularGrid
 from simulation.modules.geometry import TissueTypes
+from simulation.random import rg
 
 MAX_PHAGOSOME_LENGTH = 100
 
@@ -130,7 +131,7 @@ class PhagocyteCellList(CellList):
 
         # 1. Get cells that are alive
         for index in self.alive():
-            prob = random.random()
+            prob = rg.random()
 
             # 2. Get voxel for each cell to get molecule in that voxel
             cell = self[index]

--- a/simulation/random.py
+++ b/simulation/random.py
@@ -1,0 +1,4 @@
+from numpy.random import default_rng
+
+# Seeding with None pulls a random seed from the OS
+rg = default_rng(None)


### PR DESCRIPTION
This removes the use of Python's `random` module and NumPy's legacy `RandomState`. Instead, all random numbers are generated from a single, application-wide NumPy `Generator` instance.

Python's `random` module can't always be used, because it can't provide all of the array-valued outputs as NumPy. Since the simulation has to use NumPy for some RNG, it should use it for all RNG. This ensures that the seed is managed in only one place and that the various APIs are easy to directly compare.

NumPy's documentation discourages the use of `np.random...`, as this uses the legacy `RandomState` interface. Instead, they recommend instantiating a `Generator` instance and using it for all RNG: https://numpy.org/doc/1.18/reference/random/generator.html

For now, the new Generator is seeded with random values, mimicking the current non-deterministic behavior. If we want to change it to a pre-set seed, we can now easily do so from one place.

---

I've made these changes as a series of commits, with each commit changing only one particular API. In a few cases, minor code transformation was required, so please review the commits individually to ensure that everything is ported consistently and correctly.