### PR TITLE
Add a status enum returned with run_iterator

### DIFF
--- a/simulation/cli.py
+++ b/simulation/cli.py
@@ -41,7 +41,7 @@ def run(obj, target_time: float) -> None:
         desc='Running simulation',
         total=target_time,
     ) as pbar:
-        for state in run_iterator(config, target_time):
+        for state, _ in run_iterator(config, target_time):
             pbar.update(state.time - pbar.n)
 
 


### PR DESCRIPTION
This is necessary to distinguish between the different phases of the simulation without having to infer the status from time step information.