### PR TITLE
Having a class called Module is confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ this class.  The following is small example demonstrating some of the features:
 ```python
     import attr
 
-    from nlisim.module import Module, ModuleState
+    from nlisim.module import ModuleModel, ModuleState
 
 
-    class HelloWorld(Module):
+    class HelloWorld(ModuleModel):
         name = 'hello_world'
 
         @attr.s(kw_only=True, auto_attribs=True)

--- a/nlisim/config.py
+++ b/nlisim/config.py
@@ -7,7 +7,7 @@ import re
 from typing import List, Optional, TextIO, Type, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from nlisim.module import Module  # noqa
+    from nlisim.module import ModuleModel  # noqa
     from nlisim.state import State  # noqa
 
 
@@ -20,7 +20,7 @@ class SimulationConfig(ConfigParser):
 
     def __init__(self, *config_sources: Union[str, PurePath, TextIO, dict]) -> None:
         super().__init__(allow_no_value=False, inline_comment_prefixes=('#',))
-        self._modules: OrderedDict[str, 'Module'] = OrderedDict()
+        self._modules: OrderedDict[str, 'ModuleModel'] = OrderedDict()
 
         for config_source in config_sources:
             if isinstance(config_source, dict):
@@ -34,11 +34,11 @@ class SimulationConfig(ConfigParser):
             self.add_module(module_path)
 
     @property
-    def modules(self) -> List['Module']:
+    def modules(self) -> List['ModuleModel']:
         """Return a list of instantiated modules connected to this config."""
         return list(self._modules.values())
 
-    def add_module(self, module_ref: Union[str, Type['Module']]):
+    def add_module(self, module_ref: Union[str, Type['ModuleModel']]):
         if isinstance(module_ref, str):
             module_func = self.load_module(module_ref)
         else:
@@ -52,7 +52,7 @@ class SimulationConfig(ConfigParser):
         self._modules[module.name] = module
 
     @classmethod
-    def load_module(cls, path: str) -> Type['Module']:
+    def load_module(cls, path: str) -> Type['ModuleModel']:
         """Load a module class, returning the class constructor."""
         module_path, func_name = path.rsplit('.', 1)
         module = import_module(module_path, 'simulation')
@@ -63,14 +63,14 @@ class SimulationConfig(ConfigParser):
         return func
 
     @classmethod
-    def validate_module(cls, func: Type['Module'], path: Optional[str] = None) -> None:
+    def validate_module(cls, func: Type['ModuleModel'], path: Optional[str] = None) -> None:
         """Validate basic aspects of a module class."""
-        from nlisim.module import Module  # noqa avoid circular imports
+        from nlisim.module import ModuleModel  # noqa avoid circular imports
 
         if path is None:
             path = repr(func)
 
-        if not issubclass(func, Module):
+        if not issubclass(func, ModuleModel):
             raise TypeError(f'Invalid module class for "{path}"')
         if not func.name.isidentifier() or func.name.startswith('_'):
             raise ValueError(f'Invalid module name "{func.name}" for "{path}')

--- a/nlisim/module.py
+++ b/nlisim/module.py
@@ -118,7 +118,7 @@ class ModuleState(object):
         return value
 
 
-class Module(object):
+class ModuleModel(object):
     name: str = ''
     """A unique name for this module used for namespacing"""
 

--- a/nlisim/modules/afumigatus.py
+++ b/nlisim/modules/afumigatus.py
@@ -11,7 +11,7 @@ from scipy.spatial.transform import Rotation
 from nlisim.cell import CellData, CellList, CellType
 from nlisim.coordinates import Point
 from nlisim.grid import RectangularGrid
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.random import rg
 from nlisim.state import get_class_path, State
 
@@ -415,7 +415,7 @@ class AfumigatusState(ModuleState):
     ITER_TO_CHANGE_STATUS: int = 2
 
 
-class Afumigatus(Module):
+class Afumigatus(ModuleModel):
     name = 'afumigatus'
     StateClass = AfumigatusState
 

--- a/nlisim/modules/epithelium.py
+++ b/nlisim/modules/epithelium.py
@@ -6,7 +6,7 @@ import numpy as np
 from nlisim.cell import CellData, CellList
 from nlisim.coordinates import Point, Voxel
 from nlisim.grid import RectangularGrid
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.modules.fungus import FungusCellData, FungusCellList
 from nlisim.modules.geometry import TissueTypes
 from nlisim.random import rg
@@ -286,7 +286,7 @@ class EpitheliumState(ModuleState):
     p_internalization: float
 
 
-class Epithelium(Module):
+class Epithelium(ModuleModel):
     name = 'epithelium'
 
     StateClass = EpitheliumState

--- a/nlisim/modules/fungus.py
+++ b/nlisim/modules/fungus.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from nlisim.cell import CellData, CellList
 from nlisim.coordinates import Point, Voxel
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.modules.geometry import TissueTypes
 from nlisim.random import rg
 from nlisim.state import State
@@ -269,7 +269,7 @@ class FungusState(ModuleState):
     health: float = 100.0
 
 
-class Fungus(Module):
+class Fungus(ModuleModel):
     name = 'fungus'
     StateClass = FungusState
 

--- a/nlisim/modules/geometry.py
+++ b/nlisim/modules/geometry.py
@@ -5,7 +5,7 @@ import h5py
 import numpy as np
 import vtk
 
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.state import grid_variable, State
 from nlisim.validation import ValidationError
 
@@ -39,7 +39,7 @@ class GeometryState(ModuleState):
         return 'GeometryState(lung_tissue)'
 
 
-class Geometry(Module):
+class Geometry(ModuleModel):
     name = 'geometry'
     StateClass = GeometryState
 

--- a/nlisim/modules/macrophage.py
+++ b/nlisim/modules/macrophage.py
@@ -4,7 +4,7 @@ import numpy as np
 from nlisim.cell import CellData, CellList
 from nlisim.coordinates import Point, Voxel
 from nlisim.grid import RectangularGrid
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.modules.fungus import FungusCellData, FungusCellList
 from nlisim.modules.geometry import TissueTypes
 from nlisim.random import rg
@@ -287,7 +287,7 @@ class MacrophageState(ModuleState):
     rm: float
 
 
-class Macrophage(Module):
+class Macrophage(ModuleModel):
     name = 'macrophage'
     StateClass = MacrophageState
 

--- a/nlisim/modules/molecules.py
+++ b/nlisim/modules/molecules.py
@@ -6,7 +6,7 @@ from scipy.ndimage import convolve
 
 # from nlisim.coordinates import Voxel
 # from nlisim.grid import RectangularGrid
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.modules.geometry import GeometryState, TissueTypes
 from nlisim.molecule import MoleculeGrid, MoleculeTypes
 from nlisim.state import State
@@ -25,7 +25,7 @@ class MoleculesState(ModuleState):
     iron_max: float
 
 
-class Molecules(Module):
+class Molecules(ModuleModel):
     name = 'molecules'
     StateClass = MoleculesState
 

--- a/nlisim/modules/neutrophil.py
+++ b/nlisim/modules/neutrophil.py
@@ -6,7 +6,7 @@ import numpy as np
 from nlisim.cell import CellData, CellList
 from nlisim.coordinates import Point, Voxel
 from nlisim.grid import RectangularGrid
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.modules.fungus import FungusCellData, FungusCellList
 from nlisim.modules.geometry import TissueTypes
 from nlisim.random import rg
@@ -254,7 +254,7 @@ class NeutrophilState(ModuleState):
     age_limit: int
 
 
-class Neutrophil(Module):
+class Neutrophil(ModuleModel):
     name = 'neutrophil'
 
     StateClass = NeutrophilState

--- a/nlisim/modules/plot.py
+++ b/nlisim/modules/plot.py
@@ -2,7 +2,7 @@ import attr
 import matplotlib.pyplot as plt
 import numpy as np
 
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.state import State
 
 MAX_ARRAY_LENGTH = 1000
@@ -17,7 +17,7 @@ class PlotState(ModuleState):
     time_steps: np.ndarray = attr.ib(factory=lambda: np.zeros(MAX_ARRAY_LENGTH, dtype=float))
 
 
-class Plot(Module):
+class Plot(ModuleModel):
     name = 'plot'
     StateClass = PlotState
 

--- a/nlisim/modules/state_output.py
+++ b/nlisim/modules/state_output.py
@@ -3,7 +3,7 @@ import shutil
 
 from attr import attrib, attrs
 
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.state import State
 
 
@@ -12,7 +12,7 @@ class StateOutputState(ModuleState):
     last_save: float = attrib(default=0)
 
 
-class StateOutput(Module):
+class StateOutput(ModuleModel):
     """
     After time steps, serialize the simulation state to an HDF5 file.
 

--- a/nlisim/modules/visualization.py
+++ b/nlisim/modules/visualization.py
@@ -8,7 +8,7 @@ import vtk
 from vtk.util import numpy_support
 
 from nlisim.cell import CellList
-from nlisim.module import Module, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 from nlisim.modules.afumigatus import AfumigatusCellTreeList
 from nlisim.modules.fungus import FungusCellData
 from nlisim.modules.geometry import TissueTypes
@@ -36,7 +36,7 @@ class VisualizationState(ModuleState):
         return 'VisualizationState(last_visualize)'
 
 
-class Visualization(Module):
+class Visualization(ModuleModel):
     name = 'visualization'
 
     StateClass = VisualizationState

--- a/nlisim/solver.py
+++ b/nlisim/solver.py
@@ -6,7 +6,7 @@ from typing import Iterator, Tuple
 import attr
 
 from nlisim.config import SimulationConfig
-from nlisim.module import Module
+from nlisim.module import ModuleModel
 from nlisim.state import State
 from nlisim.validation import context as validation_context
 
@@ -38,7 +38,7 @@ def advance(state: State, target_time: float) -> Iterator[State]:
     class ModuleUpdateEvent:
         event_time: float
         previous_update: float
-        module: Module = field(compare=False)
+        module: ModuleModel = field(compare=False)
 
     # Create and fill a queue of modules to run. This allows for modules to
     # operate on disparate time scales. Modules which do not have a time step
@@ -59,7 +59,7 @@ def advance(state: State, target_time: float) -> Iterator[State]:
     while previous_time < target_time and not queue.empty():
         update_event = queue.get()
 
-        m: Module = update_event.module
+        m: ModuleModel = update_event.module
         previous_time = update_event.previous_update
         state.time = update_event.event_time
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -4,7 +4,7 @@ from tempfile import NamedTemporaryFile
 from pytest import raises
 
 from nlisim.config import SimulationConfig
-from nlisim.module import Module
+from nlisim.module import ModuleModel
 
 # Destroy all defaults!
 # def test_config_defaults():
@@ -58,17 +58,17 @@ def test_config_add_module_string():
     config = SimulationConfig()
     config.add_module('nlisim.modules.afumigatus.Afumigatus')
     assert len(config.modules) == 1
-    assert isinstance(config.modules[0], Module)
+    assert isinstance(config.modules[0], ModuleModel)
 
 
 def test_config_add_module_object():
-    class ValidModule(Module):
+    class ValidModuleModel(ModuleModel):
         name = 'ValidModule'
 
     config = SimulationConfig()
-    config.add_module(ValidModule)
+    config.add_module(ValidModuleModel)
     assert len(config.modules) == 1
-    assert isinstance(config.modules[0], ValidModule)
+    assert isinstance(config.modules[0], ValidModuleModel)
 
 
 def test_config_add_module_invalid_subclass():
@@ -81,9 +81,9 @@ def test_config_add_module_invalid_subclass():
 
 
 def test_config_add_module_invalid_name():
-    class NoNameModule(Module):
+    class NoNameModuleModel(ModuleModel):
         pass
 
     config = SimulationConfig()
     with raises(ValueError, match=r'^Invalid module name'):
-        config.add_module(NoNameModule)
+        config.add_module(NoNameModuleModel)


### PR DESCRIPTION
 when a module is both the model and state. Rename Module class to ModuleModel, mirroring ModuleState